### PR TITLE
Remove filename length constraint

### DIFF
--- a/tests/scenarios/fixtures.rs
+++ b/tests/scenarios/fixtures.rs
@@ -80,13 +80,9 @@ pub async fn before_scenario(
 ) {
     collect_function_calls(world);
 
-    let escaped_filename = NON_ALNUM_RE
+    let filename = NON_ALNUM_RE
         .replace_all(scenario.name.as_str(), "-")
         .to_string();
-    let filename = match escaped_filename.len() > 100 {
-        true => escaped_filename[..100].to_string(),
-        false => escaped_filename,
-    };
     let mut prefix = "Test".to_string();
     let mut cassette_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     cassette_dir.push(format!(


### PR DESCRIPTION
Was causing some test failures because the test name wasn't matching file name because it was getting truncated to 100 characters.