### PR TITLE
Use `genemichaels` due to build error on latest

### DIFF
--- a/.generator/src/generator/utils.py
+++ b/.generator/src/generator/utils.py
@@ -18,6 +18,7 @@ def snake_case(value):
     s1 = PATTERN_FOLLOWING_ALPHA.sub(r"\1_\2", s1).lower()
     s1 = PATTERN_WHITESPACE.sub("_", s1)
     s1 = s1.rstrip("_")
+
     return PATTERN_DOUBLE_UNDERSCORE.sub("_", s1)
 
 

--- a/generate.sh
+++ b/generate.sh
@@ -23,7 +23,9 @@ pre_commit_wrapper () {
   echo "command 'pre-commit run --all-files --hook-stage=manual ${1}' success"
 }
 
-cargo install genemichaels dd-rust-license-tool --quiet
+cargo install --git https://github.com/skarimo/genemichaels.git --rev 82e25fc0f70acb4bd7568ff803f643996d629727
+cargo install dd-rust-license-tool --quiet
+
 rm -rf src/*
 rm -rf examples/*
 pre_commit_wrapper generator


### PR DESCRIPTION
Transitive dependency renamed their function which breaks genemichaels