### PR TITLE
ci(workflows): fix use of create-github-app-token

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repository: DataDog/datadog-api-spec
+          repositories: DataDog/datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v2
         with:

--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: DataDog/datadog-api-spec
+          repositories: datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v2
         with:


### PR DESCRIPTION
### What does this PR do?

- fixes use of `create-github-app-token` with correct field name
