### PR TITLE
ci(workflows): remove use of installation mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,6 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          installation_retrieval_mode: repository
-          installation_retrieval_payload: DataDog/datadog-api-spec
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          repositories: datadog-api-spec
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -117,8 +118,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          installation_retrieval_mode: repository
-          installation_retrieval_payload: DataDog/datadog-api-spec
+          repositories: datadog-api-spec
       - name: Post status check
         uses: DataDog/github-actions/post-status-check@v2
         with:


### PR DESCRIPTION
### What does this PR do?

- removues use of `installation_retrieval_mode` from the GitHub token workflow step