### PR TITLE
Fix get_operation_host

### DIFF
--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -60,26 +60,19 @@ impl Configuration {
 
     pub fn get_operation_host(&self, operation_str: &str) -> String {
         let operation = operation_str.to_string();
-        if let Some(servers) = OPERATION_SERVERS.get(&operation) {
-            let server_index = self
-                .server_operation_index
-                .get(&operation)
-                .cloned()
-                .unwrap_or(0);
-            return servers
-                .get(server_index)
-                .expect(&format!("Server index for operation {operation} not found"))
-                .get_url(
-                    &self
-                        .server_operation_variables
-                        .get(&operation)
-                        .unwrap_or(&HashMap::new()),
-                );
-        }
-        SERVERS
-            .get(self.server_index)
-            .expect("Server index not found.")
-            .get_url(&self.server_variables)
+        let server_index = self
+            .server_operation_index
+            .get(&operation)
+            .unwrap_or(&self.server_index);
+        let server_variables = self
+            .server_operation_variables
+            .get(&operation)
+            .unwrap_or(&self.server_variables);
+        let servers = OPERATION_SERVERS.get(&operation).unwrap_or(&SERVERS);
+        servers
+            .get(*server_index)
+            .expect(&format!("Server index for operation {operation} not found"))
+            .get_url(&server_variables)
     }
 
     pub fn set_unstable_operation_enabled(&mut self, operation: &str, enabled: bool) -> bool {

--- a/src/datadog/configuration.rs
+++ b/src/datadog/configuration.rs
@@ -62,26 +62,19 @@ impl Configuration {
 
     pub fn get_operation_host(&self, operation_str: &str) -> String {
         let operation = operation_str.to_string();
-        if let Some(servers) = OPERATION_SERVERS.get(&operation) {
-            let server_index = self
-                .server_operation_index
-                .get(&operation)
-                .cloned()
-                .unwrap_or(0);
-            return servers
-                .get(server_index)
-                .expect(&format!("Server index for operation {operation} not found"))
-                .get_url(
-                    &self
-                        .server_operation_variables
-                        .get(&operation)
-                        .unwrap_or(&HashMap::new()),
-                );
-        }
-        SERVERS
-            .get(self.server_index)
-            .expect("Server index not found.")
-            .get_url(&self.server_variables)
+        let server_index = self
+            .server_operation_index
+            .get(&operation)
+            .unwrap_or(&self.server_index);
+        let server_variables = self
+            .server_operation_variables
+            .get(&operation)
+            .unwrap_or(&self.server_variables);
+        let servers = OPERATION_SERVERS.get(&operation).unwrap_or(&SERVERS);
+        servers
+            .get(*server_index)
+            .expect(&format!("Server index for operation {operation} not found"))
+            .get_url(&server_variables)
     }
 
     pub fn set_unstable_operation_enabled(&mut self, operation: &str, enabled: bool) -> bool {


### PR DESCRIPTION


### What does this PR do?

I believe the logic is wrong, we need to check if there are overrides per operation, and otherwise rely on the global values. In particular server_operation_variables and server_operation_index are not meant to be used only in the case where there is a specific server operation.

Fixes #542


### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
