### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 
 # All your base
 *                       @DataDog/web-frameworks-approvers @DataDog/web-frameworks
-LICENSE                 @DataDog/documentation @DataDog/web-frameworks-approvers @DataDog/web-frameworks
-NOTICE                  @DataDog/documentation @DataDog/web-frameworks-approvers @DataDog/web-frameworks
+LICENSE                 @DataDog/web-frameworks-approvers @DataDog/web-frameworks
+NOTICE                  @DataDog/web-frameworks-approvers @DataDog/web-frameworks


### PR DESCRIPTION
Removes Docs as CODEOWNERS from the repo. As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.

<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature."
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
