### PR TITLE
fix pre-commit workflow remove excess checkout

### DIFF
--- a/.github/workflows/reusable-pre-commit.yml
+++ b/.github/workflows/reusable-pre-commit.yml
@@ -19,29 +19,27 @@ on:
       PIPELINE_GITHUB_APP_PRIVATE_KEY:
         required: false
 
+env:
+  GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
+  GIT_AUTHOR_NAME: "ci.datadog-api-spec"
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - name: Get GitHub App token
-        if: inputs.enable-commit-changes && github.event.pull_request.head.repo.full_name == github.repository
         id: get_token
+        if: inputs.enable-commit-changes
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           fetch-depth: 0
           repository: DataDog/datadog-api-client-rust
           ref: ${{ inputs.target-branch || github.event.pull_request.head.sha || github.ref }}
           token: ${{ inputs.enable-commit-changes && steps.get_token.outputs.token || github.token }}
-      - uses: actions/checkout@v3
-        if: github.event.pull_request.head.repo.full_name != github.repository
-        with:
-          repository: DataDog/datadog-api-client-rust
-          ref: ${{ inputs.target-branch || github.ref }}
       - name: Install pre-commit
         run: python -m pip install pre-commit
       - name: set PY
@@ -66,7 +64,7 @@ jobs:
           FROM_REF: ${{ steps.commit_range.outputs.from_ref }}
           TO_REF: ${{ steps.commit_range.outputs.to_ref }}
       - name: Commit changes
-        if: failure() && inputs.enable-commit-changes && github.event.pull_request.head.repo.full_name == github.repository
+        if: ${{ failure() && inputs.enable-commit-changes }}
         run: |-
           git add -A
           git config user.name "${GIT_AUTHOR_NAME}"
@@ -76,8 +74,6 @@ jobs:
           exit 1
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
-          GIT_AUTHOR_NAME: "ci.datadog-api-spec"
       - id: pre_commit_schedule
         name: Run pre-commit in schedule
         if: github.event_name == 'schedule'


### PR DESCRIPTION
## Context

The pre-commit workflow was improperly setup causing some issue when using it from the Merge Queue


## Changes

Change the workflow so it's more consistent with the [one from the go client](https://github.com/DataDog/datadog-api-client-go/blob/2973bb7f0484df9a8f2b0e2bdb4b480131ab9082/.github/workflows/reusable-pre-commit.yml).