### PR TITLE
Allow missing descriptions.

### DIFF
--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -121,7 +121,7 @@ def cli(specs, output):
             api_path = resources_dir / "api" / filename
             api_path.parent.mkdir(parents=True, exist_ok=True)
             with api_path.open("w") as fp:
-                fp.write(api_j2.render(name=name, operations=operations, description=tags_by_name[name]["description"]))
+                fp.write(api_j2.render(name=name, operations=operations, description=tags_by_name[name].get("description")))
             all_operations.append((name, operations))
 
         mod_path = resources_dir / "api" / "mod.rs"


### PR DESCRIPTION
Generates code even if things have missing `description`s. Tested with
```
yq -i 'del(.. | .description?)' .generator/schemas/v2/openapi.yaml
pre-commit run --all-files --hook-stage=manual generator
```