### PR TITLE
Fix loop variable `v` shadowing struct fields named `v` in generated deserializer

### DIFF
--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -117,7 +117,7 @@ impl<'de> Deserialize<'de> for {{ name }} {
                 {%- endif %}
                 let mut _unparsed = false;
 
-                while let Some((k, v)) = map.next_entry::<String, serde_json::Value>()? {
+                while let Some((k, map_value)) = map.next_entry::<String, serde_json::Value>()? {
                     match k.as_str() {
                         {%- for attr, schema in model.get("properties", {}).items() %}
                         {%- set required = attr in model.required %}
@@ -126,15 +126,15 @@ impl<'de> Deserialize<'de> for {{ name }} {
                         {%- set dataType = get_type(schema, alternative_name=name + propertyName, render_option=false, version=version) %}
                         "{{ attr }}" => {
                             {%- if not nullable and not required %}
-                            if v.is_null(){% if schema.get("type") == "number" %} || v.as_str() == Some(""){% endif %} {
+                            if map_value.is_null(){% if schema.get("type") == "number" %} || map_value.as_str() == Some(""){% endif %} {
                                 continue;
                             }
                             {%- elif nullable and schema.get("type") == "number" %}
-                            if v.as_str() == Some("") {
+                            if map_value.as_str() == Some("") {
                                 continue;
                             }
                             {%- endif %}
-                            {{ propertyName }} = Some(serde_json::from_value(v).map_err(M::Error::custom)?);
+                            {{ propertyName }} = Some(serde_json::from_value(map_value).map_err(M::Error::custom)?);
                             {%- if schema.enum or schema.oneOf %}
                             if let Some(ref _{{ propertyName }}) = {{ propertyName }} {
                                 match _{{ propertyName }} {
@@ -149,7 +149,7 @@ impl<'de> Deserialize<'de> for {{ name }} {
                         {%- endfor %}
                         &_ => {
                             {%- if additionalProperties != false %}
-                            if let Ok(value) = serde_json::from_value(v.clone()) {
+                            if let Ok(value) = serde_json::from_value(map_value.clone()) {
                                 additional_properties.insert(k, value);
                             }
                             {%- else %}


### PR DESCRIPTION

The `model_simple.j2` template used `v` as the loop binding in `while let Some((k, v)) = map.next_entry()?`. Any schema property named `v` would shadow this binding, causing a type mismatch when the match arm tried to assign `Option<_>` to the loop variable `serde_json::Value`.

Rename the loop variable to `map_value` to avoid conflicts with field names.

<!--
** Requirements for Contributing to this repository **

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).
-->

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature."
If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist

Please check relevant items below:

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [ ] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.
