### PR TITLE
CRED-2150: Add OAuth/AuthZ bearer token support to Rust API client

### DIFF
--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -395,6 +395,20 @@ impl {{ structName }} {
         // build auth
         {%- set authMethods = operation.security if "security" in operation else openapi.security %}
         {%- if authMethods %}
+        {%- set ns = namespace(hasOAuth2=false) %}
+        {%- for authMethod in authMethods %}
+        {%- for name in authMethod %}
+        {%- set schema = openapi.components.securitySchemes[name] %}
+        {%- if schema.type == "oauth2" %}
+        {%- set ns.hasOAuth2 = true %}
+        {%- endif %}
+        {%- endfor %}
+        {%- endfor %}
+        {%- if ns.hasOAuth2 %}
+        if let Some(ref access_token) = local_configuration.access_token {
+            headers.insert("Authorization", HeaderValue::from_str(format!("Bearer {}", access_token).as_str()).expect("failed to parse Authorization header"));
+        } else {
+        {%- endif %}
         {%- for authMethod in authMethods %}
         {%- for name in authMethod %}
         {%- set schema = openapi.components.securitySchemes[name] %}
@@ -405,6 +419,9 @@ impl {{ structName }} {
         {%- endif %}
         {%- endfor %}
         {%- endfor %}
+        {%- if ns.hasOAuth2 %}
+        }
+        {%- endif %}
         {%- endif %}
 
         {% if formParameter %}

--- a/.generator/src/generator/templates/configuration.j2
+++ b/.generator/src/generator/templates/configuration.j2
@@ -44,6 +44,7 @@ pub struct Configuration {
     pub(crate) user_agent: String,
     pub(crate) unstable_operations: HashMap<String, bool>,
     pub(crate) auth_keys: HashMap<String, APIKey>,
+    pub(crate) access_token: Option<String>,
     pub server_index: usize,
     pub server_variables: HashMap<String, String>,
     pub server_operation_index: HashMap<String, usize>,
@@ -106,6 +107,13 @@ impl Configuration {
         self.auth_keys.insert(operation_str.to_string(), api_key);
     }
 
+    /// Set an OAuth2 access token for bearer authentication.
+    /// When set, endpoints that support the AuthZ security scheme will send
+    /// an `Authorization: Bearer <token>` header.
+    pub fn set_access_token(&mut self, token: String) {
+        self.access_token = Some(token);
+    }
+
     pub fn set_proxy_url(&mut self, proxy_url: Option<String>) {
         self.proxy_url = proxy_url;
     }
@@ -153,6 +161,7 @@ impl Default for Configuration {
             user_agent: DEFAULT_USER_AGENT.clone(),
             unstable_operations,
             auth_keys,
+            access_token: None,
             server_index: 0,
             server_variables: HashMap::from([(
                 "site".into(),

--- a/src/datadog/configuration.rs
+++ b/src/datadog/configuration.rs
@@ -46,6 +46,7 @@ pub struct Configuration {
     pub(crate) user_agent: String,
     pub(crate) unstable_operations: HashMap<String, bool>,
     pub(crate) auth_keys: HashMap<String, APIKey>,
+    pub(crate) access_token: Option<String>,
     pub server_index: usize,
     pub server_variables: HashMap<String, String>,
     pub server_operation_index: HashMap<String, usize>,
@@ -107,6 +108,13 @@ impl Configuration {
 
     pub fn set_auth_key(&mut self, operation_str: &str, api_key: APIKey) {
         self.auth_keys.insert(operation_str.to_string(), api_key);
+    }
+
+    /// Set an OAuth2 access token for bearer authentication.
+    /// When set, endpoints that support the AuthZ security scheme will send
+    /// an `Authorization: Bearer <token>` header.
+    pub fn set_access_token(&mut self, token: String) {
+        self.access_token = Some(token);
     }
 
     pub fn set_proxy_url(&mut self, proxy_url: Option<String>) {
@@ -397,6 +405,7 @@ impl Default for Configuration {
             user_agent: DEFAULT_USER_AGENT.clone(),
             unstable_operations,
             auth_keys,
+            access_token: None,
             server_index: 0,
             server_variables: HashMap::from([(
                 "site".into(),

--- a/src/datadogV1/api/api_authentication.rs
+++ b/src/datadogV1/api/api_authentication.rs
@@ -43,8 +43,7 @@ impl AuthenticationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_aws_integration.rs
+++ b/src/datadogV1/api/api_aws_integration.rs
@@ -193,8 +193,7 @@ impl AWSIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_aws_logs_integration.rs
+++ b/src/datadogV1/api/api_aws_logs_integration.rs
@@ -89,8 +89,7 @@ impl AWSLogsIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_azure_integration.rs
+++ b/src/datadogV1/api/api_azure_integration.rs
@@ -73,8 +73,7 @@ impl AzureIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_dashboard_lists.rs
+++ b/src/datadogV1/api/api_dashboard_lists.rs
@@ -74,8 +74,7 @@ impl DashboardListsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -185,20 +184,28 @@ impl DashboardListsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -338,20 +345,28 @@ impl DashboardListsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -444,20 +459,28 @@ impl DashboardListsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -548,20 +571,28 @@ impl DashboardListsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -661,20 +692,28 @@ impl DashboardListsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV1/api/api_dashboards.rs
+++ b/src/datadogV1/api/api_dashboards.rs
@@ -210,8 +210,7 @@ impl DashboardsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -322,20 +321,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -473,20 +480,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -626,20 +641,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -721,20 +744,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -869,20 +900,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -971,20 +1010,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1116,20 +1163,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1220,20 +1275,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1345,20 +1408,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1518,20 +1589,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1612,20 +1691,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1766,20 +1853,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1924,20 +2019,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2081,20 +2184,28 @@ impl DashboardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV1/api/api_downtimes.rs
+++ b/src/datadogV1/api/api_downtimes.rs
@@ -116,8 +116,7 @@ impl DowntimesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -215,20 +214,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -317,20 +324,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -469,20 +484,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -619,20 +642,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -734,20 +765,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -839,20 +878,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -946,20 +993,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV1/api/api_events.rs
+++ b/src/datadogV1/api/api_events.rs
@@ -117,8 +117,7 @@ impl EventsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -380,20 +379,28 @@ impl EventsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -537,20 +544,28 @@ impl EventsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_gcp_integration.rs
+++ b/src/datadogV1/api/api_gcp_integration.rs
@@ -65,8 +65,7 @@ impl GCPIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_hosts.rs
+++ b/src/datadogV1/api/api_hosts.rs
@@ -145,8 +145,7 @@ impl HostsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -264,20 +263,28 @@ impl HostsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -420,20 +427,28 @@ impl HostsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_ip_ranges.rs
+++ b/src/datadogV1/api/api_ip_ranges.rs
@@ -35,8 +35,7 @@ impl IPRangesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_key_management.rs
+++ b/src/datadogV1/api/api_key_management.rs
@@ -118,8 +118,7 @@ impl KeyManagementAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_logs.rs
+++ b/src/datadogV1/api/api_logs.rs
@@ -73,8 +73,7 @@ impl LogsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -203,20 +202,28 @@ impl LogsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV1/api/api_logs_indexes.rs
+++ b/src/datadogV1/api/api_logs_indexes.rs
@@ -94,8 +94,7 @@ impl LogsIndexesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_logs_pipelines.rs
+++ b/src/datadogV1/api/api_logs_pipelines.rs
@@ -113,8 +113,7 @@ impl LogsPipelinesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_metrics.rs
+++ b/src/datadogV1/api/api_metrics.rs
@@ -167,8 +167,7 @@ impl MetricsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -278,20 +277,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -398,20 +405,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -510,20 +525,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -623,20 +646,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_monitors.rs
+++ b/src/datadogV1/api/api_monitors.rs
@@ -353,8 +353,7 @@ impl MonitorsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -478,20 +477,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1044,20 +1051,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1204,20 +1219,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1328,20 +1351,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1506,20 +1537,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1634,20 +1673,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1763,20 +1810,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1872,20 +1927,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2031,20 +2094,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2190,20 +2261,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV1/api/api_notebooks.rs
+++ b/src/datadogV1/api/api_notebooks.rs
@@ -155,8 +155,7 @@ impl NotebooksAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_organizations.rs
+++ b/src/datadogV1/api/api_organizations.rs
@@ -80,8 +80,7 @@ impl OrganizationsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_pager_duty_integration.rs
+++ b/src/datadogV1/api/api_pager_duty_integration.rs
@@ -65,8 +65,7 @@ impl PagerDutyIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_security_monitoring.rs
+++ b/src/datadogV1/api/api_security_monitoring.rs
@@ -56,8 +56,7 @@ impl SecurityMonitoringAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_service_checks.rs
+++ b/src/datadogV1/api/api_service_checks.rs
@@ -56,8 +56,7 @@ impl ServiceChecksAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_service_level_objective_corrections.rs
+++ b/src/datadogV1/api/api_service_level_objective_corrections.rs
@@ -100,8 +100,7 @@ impl ServiceLevelObjectiveCorrectionsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -213,20 +212,28 @@ impl ServiceLevelObjectiveCorrectionsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -619,20 +626,28 @@ impl ServiceLevelObjectiveCorrectionsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_service_level_objectives.rs
+++ b/src/datadogV1/api/api_service_level_objectives.rs
@@ -270,8 +270,7 @@ impl ServiceLevelObjectivesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -386,20 +385,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -492,20 +499,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -657,20 +672,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -772,20 +795,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -934,20 +965,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1040,20 +1079,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1185,20 +1232,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1360,20 +1415,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1485,20 +1548,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1592,20 +1663,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV1/api/api_slack_integration.rs
+++ b/src/datadogV1/api/api_slack_integration.rs
@@ -73,8 +73,7 @@ impl SlackIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV1/api/api_snapshots.rs
+++ b/src/datadogV1/api/api_snapshots.rs
@@ -90,8 +90,7 @@ impl SnapshotsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -245,20 +244,28 @@ impl SnapshotsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_synthetics.rs
+++ b/src/datadogV1/api/api_synthetics.rs
@@ -448,8 +448,7 @@ impl SyntheticsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -561,20 +560,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -718,20 +725,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -874,20 +889,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1031,20 +1054,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1189,20 +1220,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1333,20 +1372,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1424,20 +1471,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1526,20 +1581,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1686,20 +1749,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1839,20 +1910,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1992,20 +2071,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2125,20 +2212,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2241,20 +2336,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2350,20 +2453,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2485,20 +2596,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2601,20 +2720,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2710,20 +2837,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2819,20 +2954,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2928,20 +3071,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3037,20 +3188,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3247,20 +3406,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3352,20 +3519,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3459,20 +3634,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3615,20 +3798,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3724,20 +3915,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3910,20 +4109,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4018,20 +4225,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4173,20 +4388,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4328,20 +4551,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4488,20 +4719,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4647,20 +4886,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4808,20 +5055,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4963,20 +5218,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV1/api/api_tags.rs
+++ b/src/datadogV1/api/api_tags.rs
@@ -162,8 +162,7 @@ impl TagsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -663,20 +662,28 @@ impl TagsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_usage_metering.rs
+++ b/src/datadogV1/api/api_usage_metering.rs
@@ -1102,8 +1102,7 @@ impl UsageMeteringAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -1420,20 +1419,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1552,20 +1559,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1684,20 +1699,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2008,20 +2031,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2378,20 +2409,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2510,20 +2549,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2640,20 +2687,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2769,20 +2824,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2895,20 +2958,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3027,20 +3098,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3154,20 +3233,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3282,20 +3369,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3409,20 +3504,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3541,20 +3644,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3673,20 +3784,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3799,20 +3918,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3925,20 +4052,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4059,20 +4194,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4191,20 +4334,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4323,20 +4474,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4455,20 +4614,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4587,20 +4754,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4719,20 +4894,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4856,20 +5039,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4986,20 +5177,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5112,20 +5311,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5236,20 +5443,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5376,20 +5591,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5508,20 +5731,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5640,20 +5871,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5772,20 +6011,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5904,20 +6151,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6048,20 +6303,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_users.rs
+++ b/src/datadogV1/api/api_users.rs
@@ -72,8 +72,7 @@ impl UsersAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -549,20 +548,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV1/api/api_webhooks_integration.rs
+++ b/src/datadogV1/api/api_webhooks_integration.rs
@@ -97,8 +97,7 @@ impl WebhooksIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -210,20 +209,28 @@ impl WebhooksIntegrationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_action_connection.rs
+++ b/src/datadogV2/api/api_action_connection.rs
@@ -126,8 +126,7 @@ impl ActionConnectionAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_actions_datastores.rs
+++ b/src/datadogV2/api/api_actions_datastores.rs
@@ -166,8 +166,7 @@ impl ActionsDatastoresAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_agentless_scanning.rs
+++ b/src/datadogV2/api/api_agentless_scanning.rs
@@ -180,8 +180,7 @@ impl AgentlessScanningAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -293,20 +292,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -448,20 +455,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -603,20 +618,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -755,20 +778,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -897,20 +928,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -988,20 +1027,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1079,20 +1126,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1179,20 +1234,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1288,20 +1351,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1398,20 +1469,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1504,20 +1583,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1608,20 +1695,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1714,20 +1809,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1820,20 +1923,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1924,20 +2035,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2025,20 +2144,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2179,20 +2306,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2337,20 +2472,28 @@ impl AgentlessScanningAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_api_management.rs
+++ b/src/datadogV2/api/api_api_management.rs
@@ -135,8 +135,7 @@ impl APIManagementAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -266,20 +265,28 @@ impl APIManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build form parameters
         if let Some(openapi_spec_file) = openapi_spec_file {
@@ -392,20 +399,28 @@ impl APIManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -496,20 +511,28 @@ impl APIManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -619,20 +642,28 @@ impl APIManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -743,20 +774,28 @@ impl APIManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build form parameters
         if let Some(openapi_spec_file) = openapi_spec_file {

--- a/src/datadogV2/api/api_apm.rs
+++ b/src/datadogV2/api/api_apm.rs
@@ -35,8 +35,7 @@ impl APMAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -144,20 +143,28 @@ impl APMAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_apm_retention_filters.rs
+++ b/src/datadogV2/api/api_apm_retention_filters.rs
@@ -80,8 +80,7 @@ impl APMRetentionFiltersAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_app_builder.rs
+++ b/src/datadogV2/api/api_app_builder.rs
@@ -206,8 +206,7 @@ impl AppBuilderAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_application_security.rs
+++ b/src/datadogV2/api/api_application_security.rs
@@ -117,8 +117,7 @@ impl ApplicationSecurityAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_audit.rs
+++ b/src/datadogV2/api/api_audit.rs
@@ -115,8 +115,7 @@ impl AuditAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_authn_mappings.rs
+++ b/src/datadogV2/api/api_authn_mappings.rs
@@ -121,8 +121,7 @@ impl AuthNMappingsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_aws_integration.rs
+++ b/src/datadogV2/api/api_aws_integration.rs
@@ -188,8 +188,7 @@ impl AWSIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_aws_logs_integration.rs
+++ b/src/datadogV2/api/api_aws_logs_integration.rs
@@ -36,8 +36,7 @@ impl AWSLogsIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_case_management.rs
+++ b/src/datadogV2/api/api_case_management.rs
@@ -342,8 +342,7 @@ impl CaseManagementAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -455,20 +454,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -607,20 +614,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -909,20 +924,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1061,20 +1084,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1209,20 +1240,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1357,20 +1396,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1502,20 +1549,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1661,20 +1716,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1914,20 +1977,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2007,20 +2078,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2102,20 +2181,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2201,20 +2288,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2304,20 +2399,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2413,20 +2516,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2516,20 +2627,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2631,20 +2750,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2783,20 +2910,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2942,20 +3077,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3152,20 +3295,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3258,20 +3409,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3411,20 +3570,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3557,20 +3724,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3659,20 +3834,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3819,20 +4002,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3976,20 +4167,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4129,20 +4328,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4282,20 +4489,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4435,20 +4650,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4584,20 +4807,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4732,20 +4963,28 @@ impl CaseManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_case_management_attribute.rs
+++ b/src/datadogV2/api/api_case_management_attribute.rs
@@ -64,8 +64,7 @@ impl CaseManagementAttributeAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_case_management_type.rs
+++ b/src/datadogV2/api/api_case_management_type.rs
@@ -56,8 +56,7 @@ impl CaseManagementTypeAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_change_management.rs
+++ b/src/datadogV2/api/api_change_management.rs
@@ -87,8 +87,7 @@ impl ChangeManagementAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -208,20 +207,28 @@ impl ChangeManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -377,20 +384,28 @@ impl ChangeManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -547,20 +562,28 @@ impl ChangeManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -665,20 +688,28 @@ impl ChangeManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -788,20 +819,28 @@ impl ChangeManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -961,20 +1000,28 @@ impl ChangeManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_ci_visibility_pipelines.rs
+++ b/src/datadogV2/api/api_ci_visibility_pipelines.rs
@@ -131,8 +131,7 @@ impl CIVisibilityPipelinesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -247,20 +246,28 @@ impl CIVisibilityPipelinesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -644,20 +651,28 @@ impl CIVisibilityPipelinesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -809,20 +824,28 @@ impl CIVisibilityPipelinesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_ci_visibility_tests.rs
+++ b/src/datadogV2/api/api_ci_visibility_tests.rs
@@ -123,8 +123,7 @@ impl CIVisibilityTestsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -236,20 +235,28 @@ impl CIVisibilityTestsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -472,20 +479,28 @@ impl CIVisibilityTestsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -634,20 +649,28 @@ impl CIVisibilityTestsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_cloud_authentication.rs
+++ b/src/datadogV2/api/api_cloud_authentication.rs
@@ -69,8 +69,7 @@ impl CloudAuthenticationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_cloud_cost_management.rs
+++ b/src/datadogV2/api/api_cloud_cost_management.rs
@@ -373,8 +373,7 @@ impl CloudCostManagementAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -486,20 +485,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -641,20 +648,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -799,20 +814,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -981,20 +1004,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1134,20 +1165,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1363,20 +1402,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1454,20 +1501,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1546,20 +1601,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1637,20 +1700,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1725,20 +1796,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1816,20 +1895,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2025,20 +2112,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2135,20 +2230,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2245,20 +2348,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2357,20 +2468,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2466,20 +2585,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2576,20 +2703,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2780,20 +2915,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2886,20 +3029,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2992,20 +3143,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3098,20 +3257,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3229,20 +3396,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3335,20 +3510,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3445,20 +3628,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3583,20 +3774,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3737,20 +3936,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3898,20 +4105,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4059,20 +4274,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4246,20 +4469,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4405,20 +4636,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4558,20 +4797,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -5106,20 +5353,28 @@ impl CloudCostManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_cloud_network_monitoring.rs
+++ b/src/datadogV2/api/api_cloud_network_monitoring.rs
@@ -131,8 +131,7 @@ impl CloudNetworkMonitoringAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_cloudflare_integration.rs
+++ b/src/datadogV2/api/api_cloudflare_integration.rs
@@ -72,8 +72,7 @@ impl CloudflareIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_code_coverage.rs
+++ b/src/datadogV2/api/api_code_coverage.rs
@@ -49,8 +49,7 @@ impl CodeCoverageAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -177,20 +176,28 @@ impl CodeCoverageAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -351,20 +358,28 @@ impl CodeCoverageAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_confluent_cloud.rs
+++ b/src/datadogV2/api/api_confluent_cloud.rs
@@ -112,8 +112,7 @@ impl ConfluentCloudAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_container_images.rs
+++ b/src/datadogV2/api/api_container_images.rs
@@ -83,8 +83,7 @@ impl ContainerImagesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -263,20 +262,28 @@ impl ContainerImagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_containers.rs
+++ b/src/datadogV2/api/api_containers.rs
@@ -83,8 +83,7 @@ impl ContainersAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -256,20 +255,28 @@ impl ContainersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_csm_agents.rs
+++ b/src/datadogV2/api/api_csm_agents.rs
@@ -120,8 +120,7 @@ impl CSMAgentsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_csm_coverage_analysis.rs
+++ b/src/datadogV2/api/api_csm_coverage_analysis.rs
@@ -54,8 +54,7 @@ impl CSMCoverageAnalysisAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_csm_threats.rs
+++ b/src/datadogV2/api/api_csm_threats.rs
@@ -234,8 +234,7 @@ impl CSMThreatsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_dashboard_lists.rs
+++ b/src/datadogV2/api/api_dashboard_lists.rs
@@ -66,8 +66,7 @@ impl DashboardListsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -504,20 +503,28 @@ impl DashboardListsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_data_deletion.rs
+++ b/src/datadogV2/api/api_data_deletion.rs
@@ -101,8 +101,7 @@ impl DataDeletionAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_datasets.rs
+++ b/src/datadogV2/api/api_datasets.rs
@@ -75,8 +75,7 @@ impl DatasetsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -194,20 +193,28 @@ impl DatasetsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -343,20 +350,28 @@ impl DatasetsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -448,20 +463,28 @@ impl DatasetsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -563,20 +586,28 @@ impl DatasetsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -680,20 +711,28 @@ impl DatasetsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_deployment_gates.rs
+++ b/src/datadogV2/api/api_deployment_gates.rs
@@ -184,8 +184,7 @@ impl DeploymentGatesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_domain_allowlist.rs
+++ b/src/datadogV2/api/api_domain_allowlist.rs
@@ -50,8 +50,7 @@ impl DomainAllowlistAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -160,20 +159,28 @@ impl DomainAllowlistAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -269,20 +276,28 @@ impl DomainAllowlistAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_dora_metrics.rs
+++ b/src/datadogV2/api/api_dora_metrics.rs
@@ -124,8 +124,7 @@ impl DORAMetricsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_downtimes.rs
+++ b/src/datadogV2/api/api_downtimes.rs
@@ -167,8 +167,7 @@ impl DowntimesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -270,20 +269,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -370,20 +377,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -531,20 +546,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -696,20 +719,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -862,20 +893,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -972,20 +1011,28 @@ impl DowntimesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_entity_risk_scores.rs
+++ b/src/datadogV2/api/api_entity_risk_scores.rs
@@ -106,8 +106,7 @@ impl EntityRiskScoresAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_error_tracking.rs
+++ b/src/datadogV2/api/api_error_tracking.rs
@@ -110,8 +110,7 @@ impl ErrorTrackingAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -209,20 +208,28 @@ impl ErrorTrackingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -325,20 +332,28 @@ impl ErrorTrackingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -446,20 +461,28 @@ impl ErrorTrackingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -604,20 +627,28 @@ impl ErrorTrackingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -757,20 +788,28 @@ impl ErrorTrackingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_events.rs
+++ b/src/datadogV2/api/api_events.rs
@@ -134,8 +134,7 @@ impl EventsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -412,20 +411,28 @@ impl EventsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -588,20 +595,28 @@ impl EventsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_fastly_integration.rs
+++ b/src/datadogV2/api/api_fastly_integration.rs
@@ -112,8 +112,7 @@ impl FastlyIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_feature_flags.rs
+++ b/src/datadogV2/api/api_feature_flags.rs
@@ -210,8 +210,7 @@ impl FeatureFlagsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_fleet_automation.rs
+++ b/src/datadogV2/api/api_fleet_automation.rs
@@ -253,8 +253,7 @@ impl FleetAutomationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_gcp_integration.rs
+++ b/src/datadogV2/api/api_gcp_integration.rs
@@ -97,8 +97,7 @@ impl GCPIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_google_chat_integration.rs
+++ b/src/datadogV2/api/api_google_chat_integration.rs
@@ -81,8 +81,7 @@ impl GoogleChatIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_high_availability_multi_region.rs
+++ b/src/datadogV2/api/api_high_availability_multi_region.rs
@@ -53,8 +53,7 @@ impl HighAvailabilityMultiRegionAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_incident_services.rs
+++ b/src/datadogV2/api/api_incident_services.rs
@@ -126,8 +126,7 @@ impl IncidentServicesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -247,20 +246,28 @@ impl IncidentServicesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -399,20 +406,28 @@ impl IncidentServicesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -524,20 +539,28 @@ impl IncidentServicesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -663,20 +686,28 @@ impl IncidentServicesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -786,20 +817,28 @@ impl IncidentServicesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_incident_teams.rs
+++ b/src/datadogV2/api/api_incident_teams.rs
@@ -126,8 +126,7 @@ impl IncidentTeamsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -247,20 +246,28 @@ impl IncidentTeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -396,20 +403,28 @@ impl IncidentTeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -516,20 +531,28 @@ impl IncidentTeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -655,20 +678,28 @@ impl IncidentTeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -778,20 +809,28 @@ impl IncidentTeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_incidents.rs
+++ b/src/datadogV2/api/api_incidents.rs
@@ -865,8 +865,7 @@ impl IncidentsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -1160,20 +1159,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1336,20 +1343,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1512,20 +1527,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1681,20 +1704,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1847,20 +1878,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2014,20 +2053,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2526,20 +2573,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2689,20 +2744,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2931,20 +2994,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3031,20 +3102,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3125,20 +3204,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3228,20 +3315,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3338,20 +3433,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3449,20 +3552,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3652,20 +3763,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3751,20 +3870,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3989,20 +4116,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4111,20 +4246,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4241,20 +4384,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4371,20 +4522,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4612,20 +4771,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4730,20 +4897,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4866,20 +5041,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -5301,20 +5484,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5421,20 +5612,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5549,20 +5748,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5682,20 +5889,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5916,20 +6131,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6040,20 +6263,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6216,20 +6447,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6394,20 +6633,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6874,20 +7121,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -7051,20 +7306,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -7222,20 +7485,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -7401,20 +7672,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -7581,20 +7860,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -7923,20 +8210,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -8092,20 +8387,28 @@ impl IncidentsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_integrations.rs
+++ b/src/datadogV2/api/api_integrations.rs
@@ -36,8 +36,7 @@ impl IntegrationsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_ip_allowlist.rs
+++ b/src/datadogV2/api/api_ip_allowlist.rs
@@ -53,8 +53,7 @@ impl IPAllowlistAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -161,20 +160,28 @@ impl IPAllowlistAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -268,20 +275,28 @@ impl IPAllowlistAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_jira_integration.rs
+++ b/src/datadogV2/api/api_jira_integration.rs
@@ -94,8 +94,7 @@ impl JiraIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_key_management.rs
+++ b/src/datadogV2/api/api_key_management.rs
@@ -396,8 +396,7 @@ impl KeyManagementAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_llm_observability.rs
+++ b/src/datadogV2/api/api_llm_observability.rs
@@ -334,8 +334,7 @@ impl LLMObservabilityAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_logs.rs
+++ b/src/datadogV2/api/api_logs.rs
@@ -170,8 +170,7 @@ impl LogsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_logs_archives.rs
+++ b/src/datadogV2/api/api_logs_archives.rs
@@ -115,8 +115,7 @@ impl LogsArchivesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_logs_custom_destinations.rs
+++ b/src/datadogV2/api/api_logs_custom_destinations.rs
@@ -77,8 +77,7 @@ impl LogsCustomDestinationsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_logs_metrics.rs
+++ b/src/datadogV2/api/api_logs_metrics.rs
@@ -72,8 +72,7 @@ impl LogsMetricsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_logs_restriction_queries.rs
+++ b/src/datadogV2/api/api_logs_restriction_queries.rs
@@ -182,8 +182,7 @@ impl LogsRestrictionQueriesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_metrics.rs
+++ b/src/datadogV2/api/api_metrics.rs
@@ -408,8 +408,7 @@ impl MetricsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -1496,20 +1495,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1608,20 +1615,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1818,20 +1833,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1968,20 +1991,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2197,20 +2228,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2354,20 +2393,28 @@ impl MetricsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_microsoft_teams_integration.rs
+++ b/src/datadogV2/api/api_microsoft_teams_integration.rs
@@ -160,8 +160,7 @@ impl MicrosoftTeamsIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_monitors.rs
+++ b/src/datadogV2/api/api_monitors.rs
@@ -259,8 +259,7 @@ impl MonitorsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -1133,20 +1132,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1255,20 +1262,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1394,20 +1409,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1524,20 +1547,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1630,20 +1661,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1744,20 +1783,28 @@ impl MonitorsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_network_device_monitoring.rs
+++ b/src/datadogV2/api/api_network_device_monitoring.rs
@@ -143,8 +143,7 @@ impl NetworkDeviceMonitoringAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_observability_pipelines.rs
+++ b/src/datadogV2/api/api_observability_pipelines.rs
@@ -103,8 +103,7 @@ impl ObservabilityPipelinesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_oci_integration.rs
+++ b/src/datadogV2/api/api_oci_integration.rs
@@ -81,8 +81,7 @@ impl OCIIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_okta_integration.rs
+++ b/src/datadogV2/api/api_okta_integration.rs
@@ -72,8 +72,7 @@ impl OktaIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_on_call.rs
+++ b/src/datadogV2/api/api_on_call.rs
@@ -416,8 +416,7 @@ impl OnCallAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -542,20 +541,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -706,20 +713,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -865,20 +880,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1026,20 +1049,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1171,20 +1202,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1262,20 +1301,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1357,20 +1404,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1451,20 +1506,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1566,20 +1629,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1684,20 +1755,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1804,20 +1883,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1927,20 +2014,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2047,20 +2142,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2162,20 +2265,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2287,20 +2398,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2399,20 +2518,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2521,20 +2648,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2646,20 +2781,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2816,20 +2959,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2983,20 +3134,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3155,20 +3314,28 @@ impl OnCallAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_on_call_paging.rs
+++ b/src/datadogV2/api/api_on_call_paging.rs
@@ -65,8 +65,7 @@ impl OnCallPagingAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -164,20 +163,28 @@ impl OnCallPagingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -264,20 +271,28 @@ impl OnCallPagingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -405,20 +420,28 @@ impl OnCallPagingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -493,20 +516,28 @@ impl OnCallPagingAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_opsgenie_integration.rs
+++ b/src/datadogV2/api/api_opsgenie_integration.rs
@@ -73,8 +73,7 @@ impl OpsgenieIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_org_connections.rs
+++ b/src/datadogV2/api/api_org_connections.rs
@@ -101,8 +101,7 @@ impl OrgConnectionsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -214,20 +213,28 @@ impl OrgConnectionsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -358,20 +365,28 @@ impl OrgConnectionsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -482,20 +497,28 @@ impl OrgConnectionsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -597,20 +620,28 @@ impl OrgConnectionsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_organizations.rs
+++ b/src/datadogV2/api/api_organizations.rs
@@ -80,8 +80,7 @@ impl OrganizationsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_powerpack.rs
+++ b/src/datadogV2/api/api_powerpack.rs
@@ -107,8 +107,7 @@ impl PowerpackAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -218,20 +217,28 @@ impl PowerpackAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -358,20 +365,28 @@ impl PowerpackAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -457,20 +472,28 @@ impl PowerpackAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -609,20 +632,28 @@ impl PowerpackAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -722,20 +753,28 @@ impl PowerpackAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_processes.rs
+++ b/src/datadogV2/api/api_processes.rs
@@ -98,8 +98,7 @@ impl ProcessesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -275,20 +274,28 @@ impl ProcessesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_product_analytics.rs
+++ b/src/datadogV2/api/api_product_analytics.rs
@@ -63,8 +63,7 @@ impl ProductAnalyticsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_reference_tables.rs
+++ b/src/datadogV2/api/api_reference_tables.rs
@@ -163,8 +163,7 @@ impl ReferenceTablesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -274,20 +273,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -435,20 +442,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -591,20 +606,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -735,20 +758,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -865,20 +896,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -976,20 +1015,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1081,20 +1128,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1218,20 +1273,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1315,20 +1378,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1452,20 +1523,28 @@ impl ReferenceTablesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_restriction_policies.rs
+++ b/src/datadogV2/api/api_restriction_policies.rs
@@ -74,8 +74,7 @@ impl RestrictionPoliciesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -176,20 +175,28 @@ impl RestrictionPoliciesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -281,20 +288,28 @@ impl RestrictionPoliciesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -516,20 +531,28 @@ impl RestrictionPoliciesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_roles.rs
+++ b/src/datadogV2/api/api_roles.rs
@@ -244,8 +244,7 @@ impl RolesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -363,20 +362,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -518,20 +525,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -671,20 +686,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -820,20 +843,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -960,20 +991,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1058,20 +1097,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1159,20 +1206,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1268,20 +1323,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1380,20 +1443,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1510,20 +1581,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1641,20 +1720,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1753,20 +1840,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1912,20 +2007,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2065,20 +2168,28 @@ impl RolesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_rum.rs
+++ b/src/datadogV2/api/api_rum.rs
@@ -149,8 +149,7 @@ impl RUMAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_rum_audience_management.rs
+++ b/src/datadogV2/api/api_rum_audience_management.rs
@@ -113,8 +113,7 @@ impl RumAudienceManagementAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -223,20 +222,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -368,20 +375,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -476,20 +491,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -635,20 +658,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -749,20 +780,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -911,20 +950,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1025,20 +1072,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1184,20 +1239,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1342,20 +1405,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1491,20 +1562,28 @@ impl RumAudienceManagementAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_rum_metrics.rs
+++ b/src/datadogV2/api/api_rum_metrics.rs
@@ -72,8 +72,7 @@ impl RumMetricsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_rum_replay_heatmaps.rs
+++ b/src/datadogV2/api/api_rum_replay_heatmaps.rs
@@ -94,8 +94,7 @@ impl RumReplayHeatmapsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -208,20 +207,28 @@ impl RumReplayHeatmapsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -351,20 +358,28 @@ impl RumReplayHeatmapsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -477,20 +492,28 @@ impl RumReplayHeatmapsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -588,20 +611,28 @@ impl RumReplayHeatmapsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_rum_replay_playlists.rs
+++ b/src/datadogV2/api/api_rum_replay_playlists.rs
@@ -180,8 +180,7 @@ impl RumReplayPlaylistsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -312,20 +311,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -415,20 +422,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -561,20 +576,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -703,20 +726,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -805,20 +836,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -930,20 +969,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1059,20 +1106,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1159,20 +1214,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1265,20 +1328,28 @@ impl RumReplayPlaylistsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_rum_replay_sessions.rs
+++ b/src/datadogV2/api/api_rum_replay_sessions.rs
@@ -72,8 +72,7 @@ impl RumReplaySessionsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -201,20 +200,28 @@ impl RumReplaySessionsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_rum_replay_viewership.rs
+++ b/src/datadogV2/api/api_rum_replay_viewership.rs
@@ -145,8 +145,7 @@ impl RumReplayViewershipAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -262,20 +261,28 @@ impl RumReplayViewershipAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -405,20 +412,28 @@ impl RumReplayViewershipAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -525,20 +540,28 @@ impl RumReplayViewershipAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -672,20 +695,28 @@ impl RumReplayViewershipAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_rum_retention_filters.rs
+++ b/src/datadogV2/api/api_rum_retention_filters.rs
@@ -80,8 +80,7 @@ impl RumRetentionFiltersAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_seats.rs
+++ b/src/datadogV2/api/api_seats.rs
@@ -79,8 +79,7 @@ impl SeatsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_security_monitoring.rs
+++ b/src/datadogV2/api/api_security_monitoring.rs
@@ -1856,8 +1856,7 @@ impl SecurityMonitoringAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -2074,20 +2073,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2228,20 +2235,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2387,20 +2402,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2529,20 +2552,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2646,20 +2677,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2913,20 +2952,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3069,20 +3116,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3223,20 +3278,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3380,20 +3443,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3541,20 +3612,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3699,20 +3778,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3858,20 +3945,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4016,20 +4111,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4595,20 +4698,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4693,20 +4804,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4787,20 +4906,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4879,20 +5006,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4973,20 +5108,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5161,20 +5304,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -5345,20 +5496,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -5500,20 +5659,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -5664,20 +5831,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -5828,20 +6003,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -6108,20 +6291,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6224,20 +6415,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6348,20 +6547,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6476,20 +6683,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6849,20 +7064,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -6965,20 +7188,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -7077,20 +7308,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -7198,20 +7437,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -7358,20 +7605,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -7471,20 +7726,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -7583,20 +7846,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -7695,20 +7966,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -8038,20 +8317,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -8151,20 +8438,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -8310,20 +8605,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -8428,20 +8731,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -9141,20 +9452,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -9257,20 +9576,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -9649,20 +9976,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -9830,20 +10165,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -9939,20 +10282,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -10097,20 +10448,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -10232,20 +10591,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -10422,20 +10789,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -10559,20 +10934,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -10699,20 +11082,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -11610,20 +12001,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -12092,20 +12491,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -12305,20 +12712,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -12475,20 +12890,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -12685,20 +13108,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -12847,20 +13278,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -13005,20 +13444,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -13169,20 +13616,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -13327,20 +13782,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -13491,20 +13954,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -13652,20 +14123,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -13820,20 +14299,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -13981,20 +14468,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -14127,20 +14622,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -14267,20 +14770,28 @@ impl SecurityMonitoringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_sensitive_data_scanner.rs
+++ b/src/datadogV2/api/api_sensitive_data_scanner.rs
@@ -104,8 +104,7 @@ impl SensitiveDataScannerAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_service_accounts.rs
+++ b/src/datadogV2/api/api_service_accounts.rs
@@ -135,8 +135,7 @@ impl ServiceAccountsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_service_definition.rs
+++ b/src/datadogV2/api/api_service_definition.rs
@@ -119,8 +119,7 @@ impl ServiceDefinitionAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -235,20 +234,28 @@ impl ServiceDefinitionAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -379,20 +386,28 @@ impl ServiceDefinitionAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -494,20 +509,28 @@ impl ServiceDefinitionAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -657,20 +680,28 @@ impl ServiceDefinitionAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_service_level_objectives.rs
+++ b/src/datadogV2/api/api_service_level_objectives.rs
@@ -87,8 +87,7 @@ impl ServiceLevelObjectivesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -212,20 +211,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -373,20 +380,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -490,20 +505,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -627,20 +650,28 @@ impl ServiceLevelObjectivesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_service_now_integration.rs
+++ b/src/datadogV2/api/api_service_now_integration.rs
@@ -112,8 +112,7 @@ impl ServiceNowIntegrationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_service_scorecards.rs
+++ b/src/datadogV2/api/api_service_scorecards.rs
@@ -251,8 +251,7 @@ impl ServiceScorecardsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -375,20 +374,28 @@ impl ServiceScorecardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -536,20 +543,28 @@ impl ServiceScorecardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -685,20 +700,28 @@ impl ServiceScorecardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -885,20 +908,28 @@ impl ServiceScorecardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1089,20 +1120,28 @@ impl ServiceScorecardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1195,20 +1234,28 @@ impl ServiceScorecardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1355,20 +1402,28 @@ impl ServiceScorecardsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_software_catalog.rs
+++ b/src/datadogV2/api/api_software_catalog.rs
@@ -279,8 +279,7 @@ impl SoftwareCatalogAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -378,20 +377,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -466,20 +473,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -660,20 +675,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -826,20 +849,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1010,20 +1041,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1114,20 +1153,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1223,20 +1270,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1378,20 +1433,28 @@ impl SoftwareCatalogAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_spa.rs
+++ b/src/datadogV2/api/api_spa.rs
@@ -76,8 +76,7 @@ impl SpaAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -210,6 +209,14 @@ impl SpaAPI {
         };
 
         // build auth
+        if let Some(ref access_token) = local_configuration.access_token {
+            headers.insert(
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
+            );
+        } else {
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -329,6 +336,14 @@ impl SpaAPI {
         };
 
         // build auth
+        if let Some(ref access_token) = local_configuration.access_token {
+            headers.insert(
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
+            );
+        } else {
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_spans.rs
+++ b/src/datadogV2/api/api_spans.rs
@@ -109,8 +109,7 @@ impl SpansAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -222,20 +221,28 @@ impl SpansAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -429,20 +436,28 @@ impl SpansAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -657,20 +672,28 @@ impl SpansAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_spans_metrics.rs
+++ b/src/datadogV2/api/api_spans_metrics.rs
@@ -72,8 +72,7 @@ impl SpansMetricsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_static_analysis.rs
+++ b/src/datadogV2/api/api_static_analysis.rs
@@ -163,8 +163,7 @@ impl StaticAnalysisAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -604,20 +603,28 @@ impl StaticAnalysisAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -751,20 +758,28 @@ impl StaticAnalysisAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_status_pages.rs
+++ b/src/datadogV2/api/api_status_pages.rs
@@ -559,8 +559,7 @@ impl StatusPagesAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -686,20 +685,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -859,20 +866,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1030,20 +1045,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1190,20 +1213,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1335,20 +1366,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1429,20 +1468,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1517,20 +1564,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1633,20 +1688,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1754,20 +1817,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1874,20 +1945,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1988,20 +2067,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2105,20 +2192,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2244,20 +2339,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2382,20 +2485,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2505,20 +2616,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2629,20 +2748,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2805,20 +2932,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2979,20 +3114,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3150,20 +3293,28 @@ impl StatusPagesAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_synthetics.rs
+++ b/src/datadogV2/api/api_synthetics.rs
@@ -314,8 +314,7 @@ impl SyntheticsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -422,20 +421,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -463,6 +470,7 @@ impl SyntheticsAPI {
                             Err(e) => return Err(datadog::Error::Io(e)),
                         }
                     }
+                    #[cfg(feature = "zstd")]
                     "zstd1" => {
                         let mut enc = zstd::stream::Encoder::new(Vec::new(), 0).unwrap();
                         let _ = enc.write_all(ser.into_inner().as_slice());
@@ -564,20 +572,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -605,6 +621,7 @@ impl SyntheticsAPI {
                             Err(e) => return Err(datadog::Error::Io(e)),
                         }
                     }
+                    #[cfg(feature = "zstd")]
                     "zstd1" => {
                         let mut enc = zstd::stream::Encoder::new(Vec::new(), 0).unwrap();
                         let _ = enc.write_all(ser.into_inner().as_slice());
@@ -712,20 +729,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -865,20 +890,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1018,20 +1051,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1171,20 +1212,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1330,20 +1379,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1492,20 +1549,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1607,20 +1672,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1824,20 +1897,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1934,20 +2015,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2041,20 +2130,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2171,20 +2268,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2288,20 +2393,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2329,6 +2442,7 @@ impl SyntheticsAPI {
                             Err(e) => return Err(datadog::Error::Io(e)),
                         }
                     }
+                    #[cfg(feature = "zstd")]
                     "zstd1" => {
                         let mut enc = zstd::stream::Encoder::new(Vec::new(), 0).unwrap();
                         let _ = enc.write_all(ser.into_inner().as_slice());
@@ -2452,20 +2566,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -2493,6 +2615,7 @@ impl SyntheticsAPI {
                             Err(e) => return Err(datadog::Error::Io(e)),
                         }
                     }
+                    #[cfg(feature = "zstd")]
                     "zstd1" => {
                         let mut enc = zstd::stream::Encoder::new(Vec::new(), 0).unwrap();
                         let _ = enc.write_all(ser.into_inner().as_slice());
@@ -2607,20 +2730,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2734,20 +2865,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3032,20 +3171,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -3214,20 +3361,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3484,20 +3639,28 @@ impl SyntheticsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_teams.rs
+++ b/src/datadogV2/api/api_teams.rs
@@ -520,8 +520,7 @@ impl TeamsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -639,20 +638,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -787,20 +794,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -941,20 +956,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1093,20 +1116,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1249,20 +1280,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1411,20 +1450,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1569,20 +1616,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1710,20 +1765,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1797,20 +1860,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1934,20 +2005,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2032,20 +2111,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2124,20 +2211,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2223,20 +2318,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2329,20 +2432,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2438,20 +2549,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2542,20 +2661,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2710,20 +2837,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2822,20 +2957,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2932,20 +3075,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3044,20 +3195,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3154,20 +3313,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3259,20 +3426,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3443,20 +3618,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3647,20 +3830,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -3815,20 +4006,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4001,20 +4200,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4111,20 +4318,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4202,20 +4417,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -4318,20 +4541,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4467,20 +4698,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4626,20 +4865,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4791,20 +5038,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -4952,20 +5207,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -5116,20 +5379,28 @@ impl TeamsAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_test_optimization.rs
+++ b/src/datadogV2/api/api_test_optimization.rs
@@ -89,8 +89,7 @@ impl TestOptimizationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -203,20 +202,28 @@ impl TestOptimizationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -363,20 +370,28 @@ impl TestOptimizationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -603,20 +618,28 @@ impl TestOptimizationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -766,20 +789,28 @@ impl TestOptimizationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -935,20 +966,28 @@ impl TestOptimizationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_usage_metering.rs
+++ b/src/datadogV2/api/api_usage_metering.rs
@@ -451,8 +451,7 @@ impl UsageMeteringAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -564,20 +563,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -699,20 +706,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -838,20 +853,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1003,20 +1026,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1148,20 +1179,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1319,20 +1358,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1507,20 +1554,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1635,20 +1690,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1769,20 +1832,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1879,20 +1950,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2011,20 +2090,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -2144,20 +2231,28 @@ impl UsageMeteringAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/src/datadogV2/api/api_users.rs
+++ b/src/datadogV2/api/api_users.rs
@@ -167,8 +167,7 @@ impl UsersAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -277,20 +276,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -417,20 +424,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -519,20 +534,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -625,20 +648,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -731,20 +762,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -840,20 +879,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1013,20 +1060,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -1119,20 +1174,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -1276,20 +1339,28 @@ impl UsersAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();

--- a/src/datadogV2/api/api_widgets.rs
+++ b/src/datadogV2/api/api_widgets.rs
@@ -141,8 +141,7 @@ impl WidgetsAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };

--- a/src/datadogV2/api/api_workflow_automation.rs
+++ b/src/datadogV2/api/api_workflow_automation.rs
@@ -119,8 +119,7 @@ impl WorkflowAutomationAPI {
             let builder = reqwest::Client::builder();
             #[cfg(not(target_arch = "wasm32"))]
             let builder = if let Some(proxy_url) = &config.proxy_url {
-                builder
-                    .proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
+                builder.proxy(reqwest::Proxy::all(proxy_url).expect("Failed to parse proxy URL"))
             } else {
                 builder
             };
@@ -506,20 +505,28 @@ impl WorkflowAutomationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         // build body parameters
         let output = Vec::new();
@@ -861,20 +868,28 @@ impl WorkflowAutomationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;
@@ -988,20 +1003,28 @@ impl WorkflowAutomationAPI {
         };
 
         // build auth
-        if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+        if let Some(ref access_token) = local_configuration.access_token {
             headers.insert(
-                "DD-API-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-API-KEY header"),
+                "Authorization",
+                HeaderValue::from_str(format!("Bearer {}", access_token).as_str())
+                    .expect("failed to parse Authorization header"),
             );
-        };
-        if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
-            headers.insert(
-                "DD-APPLICATION-KEY",
-                HeaderValue::from_str(local_key.key.as_str())
-                    .expect("failed to parse DD-APPLICATION-KEY header"),
-            );
-        };
+        } else {
+            if let Some(local_key) = local_configuration.auth_keys.get("apiKeyAuth") {
+                headers.insert(
+                    "DD-API-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-API-KEY header"),
+                );
+            };
+            if let Some(local_key) = local_configuration.auth_keys.get("appKeyAuth") {
+                headers.insert(
+                    "DD-APPLICATION-KEY",
+                    HeaderValue::from_str(local_key.key.as_str())
+                        .expect("failed to parse DD-APPLICATION-KEY header"),
+                );
+            };
+        }
 
         local_req_builder = local_req_builder.headers(headers);
         let local_req = local_req_builder.build()?;

--- a/tests/oauth_auth_test.rs
+++ b/tests/oauth_auth_test.rs
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+use datadog_api_client::datadog::Configuration;
+
+#[test]
+fn test_set_access_token_compiles() {
+    let mut config = Configuration::new();
+    // Verify the public API exists and accepts a String
+    config.set_access_token("my-oauth-token".to_string());
+}
+
+#[test]
+fn test_access_token_default_does_not_send_bearer() {
+    // A default configuration should not have an access token set.
+    // This is verified indirectly: if access_token were Some, the generated
+    // API code would send an Authorization header. We just verify construction works.
+    let _config = Configuration::new();
+}


### PR DESCRIPTION
## PR Stack

### API Client Libraries (closed)
All client libraries except Rust already support PATs via the existing OAuth/AuthZ code path. No new changes were needed.

- ~~**Go**: https://github.com/DataDog/datadog-api-client-go/pull/3764 — CRED-2147~~ — PATs work via existing OAuth code path
- ~~**Python**: https://github.com/DataDog/datadog-api-client-python/pull/3243 — CRED-2146~~ — PATs work via existing OAuth code path
- ~~**TypeScript**: https://github.com/DataDog/datadog-api-client-typescript/pull/3588 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**TypeScript v2**: https://github.com/DataDog/datadog-api-client-typescript/pull/3610 — CRED-2148~~ — PATs work via existing OAuth code path
- ~~**Java**: https://github.com/DataDog/datadog-api-client-java/pull/3555 — CRED-2149~~ — PATs work via existing OAuth code path
- ~~**Ruby**: https://github.com/DataDog/datadog-api-client-ruby/pull/3058 — CRED-2151~~ — PATs work via existing OAuth code path

**Rust**: The Rust client generator does not support OAuth/AuthZ, so PATs cannot be used through the client library today. When OAuth/AuthZ support is added to the Rust generator in the future ([#1438](https://github.com/DataDog/datadog-api-client-rust/pull/1438) has the approach), PATs will work automatically.

### OpenAPI Spec Changes
- https://github.com/DataDog/datadog-api-spec/pull/5164 — CRED-2275: Add PAT/SAT management API endpoints

---

## Why

All other Datadog API client libraries (Go, Python, TypeScript, Java, Ruby) support the `AuthZ` OAuth2 security scheme defined in the OpenAPI spec, which sends `Authorization: Bearer <token>`. The Rust client generator templates only handled `type: apiKey` schemes and silently skipped `type: oauth2` (AuthZ). This PR adds OAuth2/AuthZ bearer token support to bring the Rust client to parity with other clients.

## Commit structure

1. **`CRED-2150: Add OAuth/AuthZ bearer token support - templates`** — Template changes + tests (review this commit)
2. **`CRED-2150: Regenerated client code from templates`** — Generated code (137 files, can skip review)

## Summary of changes

- **`Configuration` struct**: Added `access_token: Option<String>` field and `set_access_token()` method, matching the pattern in Go (`ContextAccessToken`) and Python (`Configuration.access_token`)
- **`api.j2` template**: For endpoints that list `AuthZ` (type `oauth2`) in their security schemes, generated code now checks `access_token` first. If set, sends `Authorization: Bearer <token>`. Otherwise falls back to API key auth (`DD-API-KEY` + `DD-APPLICATION-KEY`)
- **`configuration.j2` template**: Added `access_token` field, setter, and initialization
- **Integration tests**: `tests/oauth_auth_test.rs` verifying the public API

## How it works

```rust
let mut configuration = datadog::Configuration::new();
configuration.set_access_token("your-oauth-token-or-pat".to_string());
let api = UsersAPI::with_config(configuration);
// Endpoints with AuthZ will send: Authorization: Bearer your-oauth-token-or-pat
// Endpoints without AuthZ still use DD-API-KEY + DD-APPLICATION-KEY
```

## Test plan

- [x] Integration tests pass (`cargo test --test oauth_auth_test`)
- [x] Generated code compiles (`cargo check`)
- [x] Live verification against staging using PAT via `set_access_token()` — 200 OK, users returned
- [x] Endpoints WITHOUT AuthZ (e.g., v1 Authentication) do NOT generate bearer code
- [x] Endpoints WITH AuthZ (e.g., v2 Users) correctly generate if/else bearer vs apiKey logic