### PR TITLE
Fix consecutive-acronym handling in generated examples

### DIFF
--- a/.generator/conftest.py
+++ b/.generator/conftest.py
@@ -294,9 +294,9 @@ def operation_specs(specs):
 @given(parsers.parse('an instance of "{name}" API'))
 def api(context, api_version, specs, name):
     """Return an API instance."""
-    assert name in {tag["name"].replace(" ", "") for tag in specs[api_version]["tags"]}
+    raw_tag = next(t["name"] for t in specs[api_version]["tags"] if t["name"].replace(" ", "") == name)
     name = name.replace("-", "")
-    context["api_instance"] = {"name": name}
+    context["api_instance"] = {"name": name, "raw_tag": raw_tag}
 
 
 @given(parsers.parse('operation "{name}" enabled'))

--- a/.generator/src/generator/templates/example.j2
+++ b/.generator/src/generator/templates/example.j2
@@ -1,12 +1,12 @@
 // {{ scenario.name|wordwrap(width=120, wrapstring="\n// ")}}
 
 {%- set variables = given_variables(context) %}
-{%- set parameters, imports = format_parameters(context.api_request.kwargs, spec=operation_spec, replace_values=context._replace_values, has_body=context.body, variables=variables, version=version|upper, api=context["api_instance"]["name"] | snake_case) %}
+{%- set parameters, imports = format_parameters(context.api_request.kwargs, spec=operation_spec, replace_values=context._replace_values, has_body=context.body, variables=variables, version=version|upper, api=context["api_instance"]["raw_tag"] | snake_case) %}
 {%- if context.body %}
 {%- set body, imports = format_data_with_schema(context.body.value, context.api_request.schema.spec, replace_values=context._replace_values, required=True, variables=variables, version=version|upper, imports=imports)%}
 {%- endif %}
 use datadog_api_client::datadog;
-use datadog_api_client::datadog{{ version|upper }}::api_{{context["api_instance"]["name"] | snake_case}}::{{context["api_instance"]["name"]}}API;
+use datadog_api_client::datadog{{ version|upper }}::api_{{context["api_instance"]["raw_tag"] | snake_case}}::{{context["api_instance"]["name"]}}API;
 {%- for name in imports %}
 use {{name}};
 {%- endfor %}


### PR DESCRIPTION
## Summary

Fixes broken imports in generated examples when an OpenAPI tag contains consecutive acronyms (e.g. `Bits AI SRE`).

The library file (`api_bits_ai_sre.rs`) generates correctly because `cli.py` snake_cases the raw tag. But the example template re-snake_cased the spaceless form `BitsAISRE` (set in conftest from the BDD `.feature` file), which produced `api_bits_aisre`.

Changes:
- `templates/example.j2`: snake_case the raw tag (`raw_tag`) instead of the spaceless `name`, in both the `format_parameters(api=…)` call and the `use` import.
- `.generator/conftest.py`: stash the raw tag in `context["api_instance"]` so the template can use it.

Behavior is unchanged for any tag without consecutive acronyms.

## Test plan

- [x] Renamed `Bits AI` → `Bits AI SRE` in `.generator/schemas/v2/openapi.yaml` and ran `./generate.sh`.

## Links

- Spec PR (originating change): https://github.com/DataDog/datadog-api-spec/pull/5522
- Sibling: Python — https://github.com/DataDog/datadog-api-client-python/pull/3454
- Sibling: Java — https://github.com/DataDog/datadog-api-client-java/pull/3766