### PR TITLE
Allow cursor-based pagination to query extra page until collection is empty

### DIFF
--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -241,9 +241,15 @@ impl {{ structName }} {
                     yield team;
                 }
 
+                {%- if pagination.cursorParam %}
+                if count == 0 {
+                    break;
+                }
+                {%- else %}
                 if count < page_size as usize {
                     break;
                 }
+                {%- endif %}
 
                 {%- if pagination.pageParam %}
                 {%- set getter, setter, required, schema = get_accessors(operation, pagination.pageParam) %}

--- a/src/datadogV1/api/api_dashboards.rs
+++ b/src/datadogV1/api/api_dashboards.rs
@@ -1441,7 +1441,6 @@ impl DashboardsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV1/api/api_monitors.rs
+++ b/src/datadogV1/api/api_monitors.rs
@@ -1416,7 +1416,6 @@ impl MonitorsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV1/api/api_notebooks.rs
+++ b/src/datadogV1/api/api_notebooks.rs
@@ -597,7 +597,6 @@ impl NotebooksAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV1/api/api_service_level_objective_corrections.rs
+++ b/src/datadogV1/api/api_service_level_objective_corrections.rs
@@ -555,7 +555,6 @@ impl ServiceLevelObjectiveCorrectionsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV1/api/api_service_level_objectives.rs
+++ b/src/datadogV1/api/api_service_level_objectives.rs
@@ -1277,7 +1277,6 @@ impl ServiceLevelObjectivesAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV1/api/api_synthetics.rs
+++ b/src/datadogV1/api/api_synthetics.rs
@@ -3555,7 +3555,6 @@ impl SyntheticsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_audit.rs
+++ b/src/datadogV2/api/api_audit.rs
@@ -215,7 +215,7 @@ impl AuditAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -414,7 +414,7 @@ impl AuditAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_audit.rs
+++ b/src/datadogV2/api/api_audit.rs
@@ -214,7 +214,6 @@ impl AuditAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -413,7 +412,6 @@ impl AuditAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_bits_ai.rs
+++ b/src/datadogV2/api/api_bits_ai.rs
@@ -307,7 +307,6 @@ impl BitsAIAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_case_management.rs
+++ b/src/datadogV2/api/api_case_management.rs
@@ -3077,7 +3077,6 @@ impl CaseManagementAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_ci_visibility_pipelines.rs
+++ b/src/datadogV2/api/api_ci_visibility_pipelines.rs
@@ -553,7 +553,6 @@ impl CIVisibilityPipelinesAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -751,7 +750,6 @@ impl CIVisibilityPipelinesAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_ci_visibility_pipelines.rs
+++ b/src/datadogV2/api/api_ci_visibility_pipelines.rs
@@ -554,7 +554,7 @@ impl CIVisibilityPipelinesAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -752,7 +752,7 @@ impl CIVisibilityPipelinesAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_ci_visibility_tests.rs
+++ b/src/datadogV2/api/api_ci_visibility_tests.rs
@@ -381,7 +381,6 @@ impl CIVisibilityTestsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -576,7 +575,6 @@ impl CIVisibilityTestsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_ci_visibility_tests.rs
+++ b/src/datadogV2/api/api_ci_visibility_tests.rs
@@ -382,7 +382,7 @@ impl CIVisibilityTestsAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -577,7 +577,7 @@ impl CIVisibilityTestsAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_container_images.rs
+++ b/src/datadogV2/api/api_container_images.rs
@@ -183,7 +183,6 @@ impl ContainerImagesAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_container_images.rs
+++ b/src/datadogV2/api/api_container_images.rs
@@ -184,7 +184,7 @@ impl ContainerImagesAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_containers.rs
+++ b/src/datadogV2/api/api_containers.rs
@@ -177,7 +177,6 @@ impl ContainersAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_containers.rs
+++ b/src/datadogV2/api/api_containers.rs
@@ -178,7 +178,7 @@ impl ContainersAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_downtimes.rs
+++ b/src/datadogV2/api/api_downtimes.rs
@@ -622,7 +622,6 @@ impl DowntimesAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -796,7 +795,6 @@ impl DowntimesAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_events.rs
+++ b/src/datadogV2/api/api_events.rs
@@ -501,7 +501,6 @@ impl EventsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -686,7 +685,6 @@ impl EventsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_events.rs
+++ b/src/datadogV2/api/api_events.rs
@@ -502,7 +502,7 @@ impl EventsAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -687,7 +687,7 @@ impl EventsAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_incidents.rs
+++ b/src/datadogV2/api/api_incidents.rs
@@ -6823,7 +6823,6 @@ impl IncidentsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -7001,7 +7000,6 @@ impl IncidentsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_logs.rs
+++ b/src/datadogV2/api/api_logs.rs
@@ -431,7 +431,6 @@ impl LogsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -638,7 +637,6 @@ impl LogsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_logs.rs
+++ b/src/datadogV2/api/api_logs.rs
@@ -432,7 +432,7 @@ impl LogsAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -639,7 +639,7 @@ impl LogsAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_metrics.rs
+++ b/src/datadogV2/api/api_metrics.rs
@@ -1723,7 +1723,6 @@ impl MetricsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_metrics.rs
+++ b/src/datadogV2/api/api_metrics.rs
@@ -1724,7 +1724,7 @@ impl MetricsAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_network_device_monitoring.rs
+++ b/src/datadogV2/api/api_network_device_monitoring.rs
@@ -567,7 +567,6 @@ impl NetworkDeviceMonitoringAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_powerpack.rs
+++ b/src/datadogV2/api/api_powerpack.rs
@@ -545,7 +545,6 @@ impl PowerpackAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_processes.rs
+++ b/src/datadogV2/api/api_processes.rs
@@ -193,7 +193,7 @@ impl ProcessesAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_processes.rs
+++ b/src/datadogV2/api/api_processes.rs
@@ -192,7 +192,6 @@ impl ProcessesAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_rum.rs
+++ b/src/datadogV2/api/api_rum.rs
@@ -862,7 +862,7 @@ impl RUMAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -1052,7 +1052,7 @@ impl RUMAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_rum.rs
+++ b/src/datadogV2/api/api_rum.rs
@@ -861,7 +861,6 @@ impl RUMAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -1051,7 +1050,6 @@ impl RUMAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_scorecards.rs
+++ b/src/datadogV2/api/api_scorecards.rs
@@ -1423,7 +1423,6 @@ impl ScorecardsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -1621,7 +1620,6 @@ impl ScorecardsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_security_monitoring.rs
+++ b/src/datadogV2/api/api_security_monitoring.rs
@@ -10745,7 +10745,7 @@ impl SecurityMonitoringAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(page) = resp.meta.page else { break };
@@ -11825,7 +11825,7 @@ impl SecurityMonitoringAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -12407,7 +12407,7 @@ impl SecurityMonitoringAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -14352,7 +14352,7 @@ impl SecurityMonitoringAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -14733,7 +14733,7 @@ impl SecurityMonitoringAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_security_monitoring.rs
+++ b/src/datadogV2/api/api_security_monitoring.rs
@@ -10744,7 +10744,6 @@ impl SecurityMonitoringAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -11824,7 +11823,6 @@ impl SecurityMonitoringAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -12406,7 +12404,6 @@ impl SecurityMonitoringAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -14351,7 +14348,6 @@ impl SecurityMonitoringAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -14732,7 +14728,6 @@ impl SecurityMonitoringAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_service_definition.rs
+++ b/src/datadogV2/api/api_service_definition.rs
@@ -592,7 +592,6 @@ impl ServiceDefinitionAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_software_catalog.rs
+++ b/src/datadogV2/api/api_software_catalog.rs
@@ -551,7 +551,6 @@ impl SoftwareCatalogAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -752,7 +751,6 @@ impl SoftwareCatalogAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -921,7 +919,6 @@ impl SoftwareCatalogAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_spans.rs
+++ b/src/datadogV2/api/api_spans.rs
@@ -371,7 +371,6 @@ impl SpansAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }
@@ -567,7 +566,6 @@ impl SpansAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_spans.rs
+++ b/src/datadogV2/api/api_spans.rs
@@ -372,7 +372,7 @@ impl SpansAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };
@@ -568,7 +568,7 @@ impl SpansAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_static_analysis.rs
+++ b/src/datadogV2/api/api_static_analysis.rs
@@ -1457,7 +1457,6 @@ impl StaticAnalysisAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_teams.rs
+++ b/src/datadogV2/api/api_teams.rs
@@ -2638,7 +2638,6 @@ impl TeamsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -3358,7 +3357,6 @@ impl TeamsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -3539,7 +3537,6 @@ impl TeamsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -3745,7 +3742,6 @@ impl TeamsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }
@@ -3907,7 +3903,6 @@ impl TeamsAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }

--- a/src/datadogV2/api/api_test_optimization.rs
+++ b/src/datadogV2/api/api_test_optimization.rs
@@ -685,7 +685,6 @@ impl TestOptimizationAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count == 0 {
                     break;
                 }

--- a/src/datadogV2/api/api_test_optimization.rs
+++ b/src/datadogV2/api/api_test_optimization.rs
@@ -686,7 +686,7 @@ impl TestOptimizationAPI {
                     yield team;
                 }
 
-                if count < page_size as usize {
+                if count == 0 {
                     break;
                 }
                 let Some(meta) = resp.meta else { break };

--- a/src/datadogV2/api/api_users.rs
+++ b/src/datadogV2/api/api_users.rs
@@ -1327,7 +1327,6 @@ impl UsersAPI {
                 for team in r {
                     yield team;
                 }
-
                 if count < page_size as usize {
                     break;
                 }


### PR DESCRIPTION
### What does this PR do?

Mirrors [datadog-api-client-go#3769](https://github.com/DataDog/datadog-api-client-go/pull/3769) and [datadog-api-client-java#3790](https://github.com/DataDog/datadog-api-client-java/pull/3790) for the Rust client.

Cursor-based paginators now keep querying until the response collection is empty (`count == 0`), instead of stopping early when a page returns fewer items than the requested limit (`count < page_size`). Page-offset and page-number paginations keep their existing behavior. The generator template (`api.j2`) conditionally emits the appropriate stop condition based on whether `cursorParam` is present, and all 13 affected generated API files (24 cursor-based pagination functions) have been updated accordingly. Test cassettes already had the trailing `{"data":[]}` responses pre-staged.

### Additional Notes

Compiles cleanly with `cargo check`.

### Review checklist

Please check relevant items below:

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [x] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.
  - Note: CI shouldn't be run on this Draft PR, as its expected to fail without the corresponding schema changes.