### PR TITLE
Pin all remaining workflow actions to full commit SHAs

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -32,7 +32,7 @@ jobs:
           scope: DataDog/datadog-api-spec
           policy: datadog-api-client-rust.approved_status.post-review-status
       - name: Post PR review status check
-        uses: DataDog/github-actions/post-review-status@v2
+        uses: DataDog/github-actions/post-review-status@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: datadog-api-spec

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: DataDog/labeler@glob-all
+      - uses: DataDog/labeler@5170395583c7f7ec92989fd24faffc5b6154b866 # glob-all
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     name: Upload release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         # Include all history and tags, needed for building the right version
         with:
           ref: ${{ github.event.release.tag_name }}
@@ -24,7 +24,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal --no-self-update && rustup default stable
         shell: bash
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -30,7 +30,7 @@ jobs:
         run: rustup toolchain install ${{ inputs.rust-version }} --profile minimal --no-self-update && rustup default ${{ inputs.rust-version }}
         shell: bash
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -102,7 +102,7 @@ jobs:
         run: rustup toolchain install stable --profile minimal --no-self-update && rustup default stable
         shell: bash
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -40,7 +40,7 @@ jobs:
         run: rustup toolchain install ${{ matrix.rust-version }} --profile minimal --no-self-update && rustup default ${{ matrix.rust-version }}
         shell: bash
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >-


### PR DESCRIPTION
Pins all remaining @vX floating tag action references to full commit SHAs to satisfy the enterprise policy requiring pinned actions.