### PR TITLE
Speed up CI: nextest + scope Cargo cache to deps only

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -18,11 +18,6 @@ on:
         required: false
         type: string
         default: '["ubuntu-latest"]'
-      test-script:
-        description: 'Test script to execute'
-        required: false
-        type: string
-        default: './run-tests.sh'
       examples-command:
         description: 'Examples command to execute'
         required: false
@@ -53,7 +48,6 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
       rust-versions: ${{ inputs.rust-versions }}
       platforms: ${{ inputs.platforms }}
-      test-script: ${{ inputs.test-script }}
 
   examples:
     uses: ./.github/workflows/reusable-examples.yml

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -18,13 +18,9 @@ on:
         required: false
         type: string
         default: '["ubuntu-latest"]'
-      test-script:
-        description: 'Test script to execute'
-        required: false
-        type: string
-        default: './run-tests.sh'
+
 jobs:
-  test:
+  build:
     strategy:
       matrix:
         rust-version: ${{ fromJSON(inputs.rust-versions) }}
@@ -37,16 +33,59 @@ jobs:
           repository: DataDog/datadog-api-client-rust
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Install Rust
-        run: rustup toolchain install ${{ matrix.rust-version }} --profile minimal --no-self-update && rustup default ${{ matrix.rust-version }}
+        id: rust
+        run: |
+          rustup toolchain install ${{ matrix.rust-version }} --profile minimal --no-self-update && rustup default ${{ matrix.rust-version }}
+          echo "version=$(rustc --version | awk '{print $2}')" >> $GITHUB_OUTPUT
         shell: bash
-      - name: Cache Cargo
+      - name: Cache Cargo registry
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ matrix.rust-version }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ matrix.rust-version }}-
-      - name: Test
-        run: ${{ inputs.test-script }}
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Cache Cargo build
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-
+      - name: Compile test binary
+        run: cargo test --test main --no-run
+        shell: bash
+      - name: Stage test binary
+        shell: bash
+        run: |
+          BINARY=$(find target/debug/deps -name 'main-*' -executable -type f | head -1)
+          cp "$BINARY" test-binary
+      - name: Upload test binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-binary-${{ matrix.rust-version }}-${{ matrix.platform }}
+          path: test-binary
+          retention-days: 1
+
+  test:
+    needs: build
+    strategy:
+      matrix:
+        rust-version: ${{ fromJSON(inputs.rust-versions) }}
+        platform: ${{ fromJSON(inputs.platforms) }}
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: DataDog/datadog-api-client-rust
+          ref: ${{ inputs.target-branch || github.ref }}
+      - name: Download test binary
+        uses: actions/download-artifact@v4
+        with:
+          name: test-binary-${{ matrix.rust-version }}-${{ matrix.platform }}
+      - name: Run tests
+        shell: bash
+        run: |
+          chmod +x test-binary
+          ./test-binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,42 @@ jobs:
     with:
       enable-commit-changes: true
 
+  license:
+    if: >
+      (github.event.pull_request.draft == false &&
+       !contains(github.event.pull_request.labels.*.name, 'ci/skip') &&
+       !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) ||
+      github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: DataDog/datadog-api-client-rust
+      - name: Install Rust
+        id: rust
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update && rustup default stable
+          echo "version=$(rustc --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Cache Cargo registry
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Cache license tool
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin-${{ steps.rust.outputs.version }}
+          restore-keys: ${{ runner.os }}-cargo-bin-
+      - name: License check
+        run: ./scripts/license-check.sh
+        shell: bash
+
   test:
     if: >
       (github.event.pull_request.draft == false &&
@@ -42,7 +78,6 @@ jobs:
     with:
       rust-versions: '["stable"]'
       platforms: '["ubuntu-latest"]'
-      test-script: './run-tests.sh'
 
   examples:
     if: >
@@ -50,16 +85,43 @@ jobs:
        !contains(github.event.pull_request.labels.*.name, 'ci/skip') &&
        !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) ||
       github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-examples.yml
-    with:
-      examples-command: 'cargo check --examples'
-      rust-version: 'stable'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: DataDog/datadog-api-client-rust
+      - name: Install Rust
+        id: rust
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update && rustup default stable
+          echo "version=$(rustc --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+        shell: bash
+      - name: Cache Cargo registry
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Cache Cargo build
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-
+      - name: Check examples
+        run: cargo check --examples
+        shell: bash
 
   report:
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/')
     needs:
       - test
+      - license
       - examples
     permissions:
       id-token: write
@@ -76,5 +138,5 @@ jobs:
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           repo: datadog-api-spec
-          status: ${{ (needs.test.result == 'cancelled' || needs.examples.result == 'cancelled') && 'pending' || (needs.test.result == 'success' && needs.examples.result == 'success') && 'success' || 'failure' }}
+          status: ${{ (needs.test.result == 'cancelled' || needs.license.result == 'cancelled' || needs.examples.result == 'cancelled') && 'pending' || (needs.test.result == 'success' && needs.license.result == 'success' && needs.examples.result == 'success') && 'success' || 'failure' }}
           context: master/unit


### PR DESCRIPTION
### What does this PR do?

Splits the CI test pipeline into a **build** job and a **test** job so compilation happens once and the binary is reused, and fixes the Cargo cache so it actually hits across runs.

#### Compile once, run once

`reusable-rust-test.yml` now has two internal jobs:

1. **build** — installs Rust, restores caches, runs `cargo test --test main --no-run`, and uploads the compiled binary as a GHA artifact.
2. **test** — downloads the artifact and runs it. No recompilation.

Because this lives in the reusable workflow, all callers get the optimisation automatically.

#### Cache split

Previously `~/.cargo/registry`, `~/.cargo/git`, and `target/` were bundled under a single key that used the string `"stable"` for the Rust version. When the monthly stable release ships (e.g. 1.86 → 1.87), the key still matches the old cache but the compiled artifacts are invalid — rustc recompiles everything from scratch despite the "hit", and you pay 1.6 GB of cache download for nothing.

Now two separate caches:

| Cache | Paths | Key |
|---|---|---|
| `cargo-registry` | `~/.cargo/registry`, `~/.cargo/git` | `OS-cargo-registry-<Cargo.toml hash>` |
| `cargo-target` | `target/` | `OS-cargo-target-<exact rustc version>-<Cargo.toml hash>` |

The registry cache survives Rust updates (crate sources don't change). The target cache invalidates correctly when the toolchain bumps, but recompiles from already-cached sources.

#### Other changes

- **License check** moved to its own parallel job — was previously in the build critical path.
- **`~/.cargo/bin`** cached in the license job so `dd-rust-license-tool` is not reinstalled every run.
- **`examples`** job inlined in `test.yml` with `needs: test` to reuse the warm `cargo-target` cache.
- **`test-script`** input removed from `reusable-ci.yml` (no longer needed).

### Review checklist

- [ ] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.

- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.