### PR TITLE
Fix operation_id variable shadowing in Rust generator

### DIFF
--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -296,10 +296,10 @@ impl {{ structName }} {
     {%- endif %}
     pub async fn {{operation.operationId | snake_case}}_with_http_info(&self{% for name, parameter in requiredParams %}, {{name|variable_name}}: {{ get_type_for_parameter(parameter, version) }}{% endfor %}{% if operation|has_optional_parameter %}, params: {{operation.operationId}}OptionalParams{% endif %}) -> Result<datadog::ResponseContent<{% if returnType %}{{returnType}}{% else %}(){% endif %}>, datadog::Error<{{operation.operationId}}Error>> {
         let local_configuration = &self.config;
-        let operation_id = "{{ version }}.{{ operation.operationId | snake_case }}";
+        let local_operation_id = "{{ version }}.{{ operation.operationId | snake_case }}";
         {%- if "x-unstable" in operation %}
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation '{{ version }}.{{ operation.operationId | snake_case }}' is not enabled".to_string(),
@@ -319,7 +319,7 @@ impl {{ structName }} {
 
         let local_uri_str = format!(
             "{}{{path}}",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
             {%- for name, parameter in operation|parameters if parameter.in == "path" %}, {{ name|variable_name }}=
             {%- if parameter.schema.type == "string" %}
             datadog::urlencode({{ name|variable_name }}{% if not parameter.required %}.unwrap(){% elif parameter.schema.nullable %}.unwrap(){% endif %}{% if parameter.schema.type == "array" %}.join(",").as_ref(){% endif %}{% if parameter.schema.format == "uuid" or parameter.schema.enum %}.to_string(){% endif %})

--- a/src/datadogV1/api/api_authentication.rs
+++ b/src/datadogV1/api/api_authentication.rs
@@ -124,13 +124,13 @@ impl AuthenticationAPI {
         datadog::Error<ValidateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.validate";
+        let local_operation_id = "v1.validate";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV1/api/api_aws_integration.rs
+++ b/src/datadogV1/api/api_aws_integration.rs
@@ -282,13 +282,13 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateAWSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_aws_account";
+        let local_operation_id = "v1.create_aws_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -440,13 +440,13 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateAWSEventBridgeSourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_aws_event_bridge_source";
+        let local_operation_id = "v1.create_aws_event_bridge_source";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/event_bridge",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -595,13 +595,13 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateAWSTagFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_aws_tag_filter";
+        let local_operation_id = "v1.create_aws_tag_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/filtering",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -750,13 +750,13 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateNewAWSExternalIDError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_new_aws_external_id";
+        let local_operation_id = "v1.create_new_aws_external_id";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/generate_new_external_id",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -905,13 +905,13 @@ impl AWSIntegrationAPI {
         datadog::Error<DeleteAWSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_aws_account";
+        let local_operation_id = "v1.delete_aws_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1063,13 +1063,13 @@ impl AWSIntegrationAPI {
         datadog::Error<DeleteAWSEventBridgeSourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_aws_event_bridge_source";
+        let local_operation_id = "v1.delete_aws_event_bridge_source";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/event_bridge",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1218,13 +1218,13 @@ impl AWSIntegrationAPI {
         datadog::Error<DeleteAWSTagFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_aws_tag_filter";
+        let local_operation_id = "v1.delete_aws_tag_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/filtering",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1371,7 +1371,7 @@ impl AWSIntegrationAPI {
         datadog::Error<ListAWSAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_aws_accounts";
+        let local_operation_id = "v1.list_aws_accounts";
 
         // unbox and build optional parameters
         let account_id = params.account_id;
@@ -1382,7 +1382,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1495,13 +1495,13 @@ impl AWSIntegrationAPI {
         datadog::Error<ListAWSEventBridgeSourcesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_aws_event_bridge_sources";
+        let local_operation_id = "v1.list_aws_event_bridge_sources";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/event_bridge",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1603,13 +1603,13 @@ impl AWSIntegrationAPI {
         datadog::Error<ListAWSTagFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_aws_tag_filters";
+        let local_operation_id = "v1.list_aws_tag_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/filtering",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1708,13 +1708,13 @@ impl AWSIntegrationAPI {
         datadog::Error<ListAvailableAWSNamespacesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_available_aws_namespaces";
+        let local_operation_id = "v1.list_available_aws_namespaces";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/available_namespace_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1816,7 +1816,7 @@ impl AWSIntegrationAPI {
         datadog::Error<UpdateAWSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_aws_account";
+        let local_operation_id = "v1.update_aws_account";
 
         // unbox and build optional parameters
         let account_id = params.account_id;
@@ -1827,7 +1827,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV1/api/api_aws_logs_integration.rs
+++ b/src/datadogV1/api/api_aws_logs_integration.rs
@@ -186,13 +186,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<CheckAWSLogsLambdaAsyncError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.check_aws_logs_lambda_async";
+        let local_operation_id = "v1.check_aws_logs_lambda_async";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/logs/check_async",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -362,13 +362,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<CheckAWSLogsServicesAsyncError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.check_aws_logs_services_async";
+        let local_operation_id = "v1.check_aws_logs_services_async";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/logs/services_async",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -517,13 +517,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<CreateAWSLambdaARNError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_aws_lambda_arn";
+        let local_operation_id = "v1.create_aws_lambda_arn";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/logs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -672,13 +672,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<DeleteAWSLambdaARNError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_aws_lambda_arn";
+        let local_operation_id = "v1.delete_aws_lambda_arn";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/logs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -827,13 +827,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<EnableAWSLogServicesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.enable_aws_log_services";
+        let local_operation_id = "v1.enable_aws_log_services";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/logs/services",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -980,13 +980,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<ListAWSLogsIntegrationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_aws_logs_integrations";
+        let local_operation_id = "v1.list_aws_logs_integrations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/logs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1086,13 +1086,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<ListAWSLogsServicesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_aws_logs_services";
+        let local_operation_id = "v1.list_aws_logs_services";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/aws/logs/services",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV1/api/api_azure_integration.rs
+++ b/src/datadogV1/api/api_azure_integration.rs
@@ -168,13 +168,13 @@ impl AzureIntegrationAPI {
         datadog::Error<CreateAzureIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_azure_integration";
+        let local_operation_id = "v1.create_azure_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/azure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -323,13 +323,13 @@ impl AzureIntegrationAPI {
         datadog::Error<DeleteAzureIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_azure_integration";
+        let local_operation_id = "v1.delete_azure_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/azure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -474,13 +474,13 @@ impl AzureIntegrationAPI {
         datadog::Error<ListAzureIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_azure_integration";
+        let local_operation_id = "v1.list_azure_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/azure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -581,13 +581,13 @@ impl AzureIntegrationAPI {
         datadog::Error<UpdateAzureHostFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_azure_host_filters";
+        let local_operation_id = "v1.update_azure_host_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/azure/host_filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -740,13 +740,13 @@ impl AzureIntegrationAPI {
         datadog::Error<UpdateAzureIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_azure_integration";
+        let local_operation_id = "v1.update_azure_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/azure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV1/api/api_dashboard_lists.rs
+++ b/src/datadogV1/api/api_dashboard_lists.rs
@@ -155,13 +155,13 @@ impl DashboardListsAPI {
         datadog::Error<CreateDashboardListError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_dashboard_list";
+        let local_operation_id = "v1.create_dashboard_list";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/lists/manual",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -308,13 +308,13 @@ impl DashboardListsAPI {
         datadog::Error<DeleteDashboardListError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_dashboard_list";
+        let local_operation_id = "v1.delete_dashboard_list";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/lists/manual/{list_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             list_id = list_id
         );
         let mut local_req_builder =
@@ -414,13 +414,13 @@ impl DashboardListsAPI {
         datadog::Error<GetDashboardListError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_dashboard_list";
+        let local_operation_id = "v1.get_dashboard_list";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/lists/manual/{list_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             list_id = list_id
         );
         let mut local_req_builder =
@@ -519,13 +519,13 @@ impl DashboardListsAPI {
         datadog::Error<ListDashboardListsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_dashboard_lists";
+        let local_operation_id = "v1.list_dashboard_lists";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/lists/manual",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -630,13 +630,13 @@ impl DashboardListsAPI {
         datadog::Error<UpdateDashboardListError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_dashboard_list";
+        let local_operation_id = "v1.update_dashboard_list";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/lists/manual/{list_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             list_id = list_id
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_dashboards.rs
+++ b/src/datadogV1/api/api_dashboards.rs
@@ -292,13 +292,13 @@ impl DashboardsAPI {
         datadog::Error<CreateDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_dashboard";
+        let local_operation_id = "v1.create_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -443,13 +443,13 @@ impl DashboardsAPI {
         datadog::Error<CreatePublicDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_public_dashboard";
+        let local_operation_id = "v1.create_public_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/public",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -596,13 +596,13 @@ impl DashboardsAPI {
         datadog::Error<DeleteDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_dashboard";
+        let local_operation_id = "v1.delete_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/{dashboard_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id)
         );
         let mut local_req_builder =
@@ -691,13 +691,13 @@ impl DashboardsAPI {
         body: crate::datadogV1::model::DashboardBulkDeleteRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDashboardsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_dashboards";
+        let local_operation_id = "v1.delete_dashboards";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -839,13 +839,13 @@ impl DashboardsAPI {
         datadog::Error<DeletePublicDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_public_dashboard";
+        let local_operation_id = "v1.delete_public_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/public/{token}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token = datadog::urlencode(token)
         );
         let mut local_req_builder =
@@ -940,13 +940,13 @@ impl DashboardsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeletePublicDashboardInvitationError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_public_dashboard_invitation";
+        let local_operation_id = "v1.delete_public_dashboard_invitation";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/public/{token}/invitation",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token = datadog::urlencode(token)
         );
         let mut local_req_builder =
@@ -1086,13 +1086,13 @@ impl DashboardsAPI {
         datadog::Error<GetDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_dashboard";
+        let local_operation_id = "v1.get_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/{dashboard_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id)
         );
         let mut local_req_builder =
@@ -1190,13 +1190,13 @@ impl DashboardsAPI {
         datadog::Error<GetPublicDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_public_dashboard";
+        let local_operation_id = "v1.get_public_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/public/{token}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token = datadog::urlencode(token)
         );
         let mut local_req_builder =
@@ -1302,7 +1302,7 @@ impl DashboardsAPI {
         datadog::Error<GetPublicDashboardInvitationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_public_dashboard_invitations";
+        let local_operation_id = "v1.get_public_dashboard_invitations";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1312,7 +1312,7 @@ impl DashboardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/public/{token}/invitation",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token = datadog::urlencode(token)
         );
         let mut local_req_builder =
@@ -1465,7 +1465,7 @@ impl DashboardsAPI {
         datadog::Error<ListDashboardsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_dashboards";
+        let local_operation_id = "v1.list_dashboards";
 
         // unbox and build optional parameters
         let filter_shared = params.filter_shared;
@@ -1477,7 +1477,7 @@ impl DashboardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1581,13 +1581,13 @@ impl DashboardsAPI {
         body: crate::datadogV1::model::DashboardRestoreRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RestoreDashboardsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.restore_dashboards";
+        let local_operation_id = "v1.restore_dashboards";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -1734,13 +1734,13 @@ impl DashboardsAPI {
         datadog::Error<SendPublicDashboardInvitationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.send_public_dashboard_invitation";
+        let local_operation_id = "v1.send_public_dashboard_invitation";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/public/{token}/invitation",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token = datadog::urlencode(token)
         );
         let mut local_req_builder =
@@ -1892,13 +1892,13 @@ impl DashboardsAPI {
         datadog::Error<UpdateDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_dashboard";
+        let local_operation_id = "v1.update_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/{dashboard_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id)
         );
         let mut local_req_builder =
@@ -2049,13 +2049,13 @@ impl DashboardsAPI {
         datadog::Error<UpdatePublicDashboardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_public_dashboard";
+        let local_operation_id = "v1.update_public_dashboard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/dashboard/public/{token}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token = datadog::urlencode(token)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_downtimes.rs
+++ b/src/datadogV1/api/api_downtimes.rs
@@ -185,13 +185,13 @@ impl DowntimesAPI {
         downtime_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CancelDowntimeError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.cancel_downtime";
+        let local_operation_id = "v1.cancel_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/downtime/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = downtime_id
         );
         let mut local_req_builder =
@@ -287,13 +287,13 @@ impl DowntimesAPI {
         datadog::Error<CancelDowntimesByScopeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.cancel_downtimes_by_scope";
+        let local_operation_id = "v1.cancel_downtimes_by_scope";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/downtime/cancel/by_scope",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -439,13 +439,13 @@ impl DowntimesAPI {
         datadog::Error<CreateDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_downtime";
+        let local_operation_id = "v1.create_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/downtime",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -589,13 +589,13 @@ impl DowntimesAPI {
         datadog::Error<GetDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_downtime";
+        let local_operation_id = "v1.get_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/downtime/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = downtime_id
         );
         let mut local_req_builder =
@@ -692,7 +692,7 @@ impl DowntimesAPI {
         datadog::Error<ListDowntimesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_downtimes";
+        let local_operation_id = "v1.list_downtimes";
 
         // unbox and build optional parameters
         let current_only = params.current_only;
@@ -702,7 +702,7 @@ impl DowntimesAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/downtime",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -809,13 +809,13 @@ impl DowntimesAPI {
         datadog::Error<ListMonitorDowntimesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_monitor_downtimes";
+        let local_operation_id = "v1.list_monitor_downtimes";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/{monitor_id}/downtimes",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             monitor_id = monitor_id
         );
         let mut local_req_builder =
@@ -915,13 +915,13 @@ impl DowntimesAPI {
         datadog::Error<UpdateDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_downtime";
+        let local_operation_id = "v1.update_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/downtime/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = downtime_id
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_events.rs
+++ b/src/datadogV1/api/api_events.rs
@@ -200,13 +200,13 @@ impl EventsAPI {
         datadog::Error<CreateEventError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_event";
+        let local_operation_id = "v1.create_event";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -350,13 +350,13 @@ impl EventsAPI {
         datadog::Error<GetEventError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_event";
+        let local_operation_id = "v1.get_event";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/events/{event_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             event_id = event_id
         );
         let mut local_req_builder =
@@ -473,7 +473,7 @@ impl EventsAPI {
         datadog::Error<ListEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_events";
+        let local_operation_id = "v1.list_events";
 
         // unbox and build optional parameters
         let priority = params.priority;
@@ -487,7 +487,7 @@ impl EventsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV1/api/api_gcp_integration.rs
+++ b/src/datadogV1/api/api_gcp_integration.rs
@@ -148,13 +148,13 @@ impl GCPIntegrationAPI {
         datadog::Error<CreateGCPIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_gcp_integration";
+        let local_operation_id = "v1.create_gcp_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/gcp",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -303,13 +303,13 @@ impl GCPIntegrationAPI {
         datadog::Error<DeleteGCPIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_gcp_integration";
+        let local_operation_id = "v1.delete_gcp_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/gcp",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -454,13 +454,13 @@ impl GCPIntegrationAPI {
         datadog::Error<ListGCPIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_gcp_integration";
+        let local_operation_id = "v1.list_gcp_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/gcp",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -566,13 +566,13 @@ impl GCPIntegrationAPI {
         datadog::Error<UpdateGCPIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_gcp_integration";
+        let local_operation_id = "v1.update_gcp_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/gcp",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV1/api/api_hosts.rs
+++ b/src/datadogV1/api/api_hosts.rs
@@ -227,7 +227,7 @@ impl HostsAPI {
         datadog::Error<GetHostTotalsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_host_totals";
+        let local_operation_id = "v1.get_host_totals";
 
         // unbox and build optional parameters
         let from = params.from;
@@ -236,7 +236,7 @@ impl HostsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/hosts/totals",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -348,7 +348,7 @@ impl HostsAPI {
         datadog::Error<ListHostsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_hosts";
+        let local_operation_id = "v1.list_hosts";
 
         // unbox and build optional parameters
         let filter = params.filter;
@@ -364,7 +364,7 @@ impl HostsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/hosts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -496,13 +496,13 @@ impl HostsAPI {
         datadog::Error<MuteHostError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.mute_host";
+        let local_operation_id = "v1.mute_host";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/host/{host_name}/mute",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             host_name = datadog::urlencode(host_name)
         );
         let mut local_req_builder =
@@ -647,13 +647,13 @@ impl HostsAPI {
         datadog::Error<UnmuteHostError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.unmute_host";
+        let local_operation_id = "v1.unmute_host";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/host/{host_name}/unmute",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             host_name = datadog::urlencode(host_name)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_ip_ranges.rs
+++ b/src/datadogV1/api/api_ip_ranges.rs
@@ -113,11 +113,14 @@ impl IPRangesAPI {
         datadog::Error<GetIPRangesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_ip_ranges";
+        let local_operation_id = "v1.get_ip_ranges";
 
         let local_client = &self.client;
 
-        let local_uri_str = format!("{}/", local_configuration.get_operation_host(operation_id));
+        let local_uri_str = format!(
+            "{}/",
+            local_configuration.get_operation_host(local_operation_id)
+        );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
 

--- a/src/datadogV1/api/api_key_management.rs
+++ b/src/datadogV1/api/api_key_management.rs
@@ -202,13 +202,13 @@ impl KeyManagementAPI {
         datadog::Error<CreateAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_api_key";
+        let local_operation_id = "v1.create_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/api_key",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -360,13 +360,13 @@ impl KeyManagementAPI {
         datadog::Error<CreateApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_application_key";
+        let local_operation_id = "v1.create_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/application_key",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -516,13 +516,13 @@ impl KeyManagementAPI {
         datadog::Error<DeleteAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_api_key";
+        let local_operation_id = "v1.delete_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/api_key/{key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             key = datadog::urlencode(key)
         );
         let mut local_req_builder =
@@ -628,13 +628,13 @@ impl KeyManagementAPI {
         datadog::Error<DeleteApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_application_key";
+        let local_operation_id = "v1.delete_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/application_key/{key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             key = datadog::urlencode(key)
         );
         let mut local_req_builder =
@@ -738,13 +738,13 @@ impl KeyManagementAPI {
         datadog::Error<GetAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_api_key";
+        let local_operation_id = "v1.get_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/api_key/{key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             key = datadog::urlencode(key)
         );
         let mut local_req_builder =
@@ -850,13 +850,13 @@ impl KeyManagementAPI {
         datadog::Error<GetApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_application_key";
+        let local_operation_id = "v1.get_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/application_key/{key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             key = datadog::urlencode(key)
         );
         let mut local_req_builder =
@@ -958,13 +958,13 @@ impl KeyManagementAPI {
         datadog::Error<ListAPIKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_api_keys";
+        let local_operation_id = "v1.list_api_keys";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/api_key",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1069,13 +1069,13 @@ impl KeyManagementAPI {
         datadog::Error<ListApplicationKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_application_keys";
+        let local_operation_id = "v1.list_application_keys";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/application_key",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1180,13 +1180,13 @@ impl KeyManagementAPI {
         datadog::Error<UpdateAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_api_key";
+        let local_operation_id = "v1.update_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/api_key/{key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             key = datadog::urlencode(key)
         );
         let mut local_req_builder =
@@ -1341,13 +1341,13 @@ impl KeyManagementAPI {
         datadog::Error<UpdateApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_application_key";
+        let local_operation_id = "v1.update_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/application_key/{key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             key = datadog::urlencode(key)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_logs.rs
+++ b/src/datadogV1/api/api_logs.rs
@@ -173,13 +173,13 @@ impl LogsAPI {
         datadog::Error<ListLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_logs";
+        let local_operation_id = "v1.list_logs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs-queries/list",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -362,7 +362,7 @@ impl LogsAPI {
         datadog::Error<SubmitLogError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.submit_log";
+        let local_operation_id = "v1.submit_log";
 
         // unbox and build optional parameters
         let content_encoding = params.content_encoding;
@@ -372,7 +372,7 @@ impl LogsAPI {
 
         let local_uri_str = format!(
             "{}/v1/input",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV1/api/api_logs_indexes.rs
+++ b/src/datadogV1/api/api_logs_indexes.rs
@@ -174,13 +174,13 @@ impl LogsIndexesAPI {
         datadog::Error<CreateLogsIndexError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_logs_index";
+        let local_operation_id = "v1.create_logs_index";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/indexes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -315,13 +315,13 @@ impl LogsIndexesAPI {
         name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLogsIndexError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_logs_index";
+        let local_operation_id = "v1.delete_logs_index";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/indexes/{name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             name = datadog::urlencode(name)
         );
         let mut local_req_builder =
@@ -414,13 +414,13 @@ impl LogsIndexesAPI {
         datadog::Error<GetLogsIndexError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_logs_index";
+        let local_operation_id = "v1.get_logs_index";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/indexes/{name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             name = datadog::urlencode(name)
         );
         let mut local_req_builder =
@@ -516,13 +516,13 @@ impl LogsIndexesAPI {
         datadog::Error<GetLogsIndexOrderError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_logs_index_order";
+        let local_operation_id = "v1.get_logs_index_order";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/index-order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -621,13 +621,13 @@ impl LogsIndexesAPI {
         datadog::Error<ListLogIndexesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_log_indexes";
+        let local_operation_id = "v1.list_log_indexes";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/indexes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -736,13 +736,13 @@ impl LogsIndexesAPI {
         datadog::Error<UpdateLogsIndexError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_logs_index";
+        let local_operation_id = "v1.update_logs_index";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/indexes/{name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             name = datadog::urlencode(name)
         );
         let mut local_req_builder =
@@ -890,13 +890,13 @@ impl LogsIndexesAPI {
         datadog::Error<UpdateLogsIndexOrderError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_logs_index_order";
+        let local_operation_id = "v1.update_logs_index_order";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/index-order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV1/api/api_logs_pipelines.rs
+++ b/src/datadogV1/api/api_logs_pipelines.rs
@@ -194,13 +194,13 @@ impl LogsPipelinesAPI {
         datadog::Error<CreateLogsPipelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_logs_pipeline";
+        let local_operation_id = "v1.create_logs_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/pipelines",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -335,13 +335,13 @@ impl LogsPipelinesAPI {
         pipeline_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLogsPipelineError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_logs_pipeline";
+        let local_operation_id = "v1.delete_logs_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/pipelines/{pipeline_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             pipeline_id = datadog::urlencode(pipeline_id)
         );
         let mut local_req_builder =
@@ -436,13 +436,13 @@ impl LogsPipelinesAPI {
         datadog::Error<GetLogsPipelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_logs_pipeline";
+        let local_operation_id = "v1.get_logs_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/pipelines/{pipeline_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             pipeline_id = datadog::urlencode(pipeline_id)
         );
         let mut local_req_builder =
@@ -543,13 +543,13 @@ impl LogsPipelinesAPI {
         datadog::Error<GetLogsPipelineOrderError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_logs_pipeline_order";
+        let local_operation_id = "v1.get_logs_pipeline_order";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/pipeline-order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -649,13 +649,13 @@ impl LogsPipelinesAPI {
         datadog::Error<ListLogsPipelinesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_logs_pipelines";
+        let local_operation_id = "v1.list_logs_pipelines";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/pipelines",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -765,13 +765,13 @@ impl LogsPipelinesAPI {
         datadog::Error<UpdateLogsPipelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_logs_pipeline";
+        let local_operation_id = "v1.update_logs_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/pipelines/{pipeline_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             pipeline_id = datadog::urlencode(pipeline_id)
         );
         let mut local_req_builder =
@@ -927,13 +927,13 @@ impl LogsPipelinesAPI {
         datadog::Error<UpdateLogsPipelineOrderError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_logs_pipeline_order";
+        let local_operation_id = "v1.update_logs_pipeline_order";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/logs/config/pipeline-order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV1/api/api_metrics.rs
+++ b/src/datadogV1/api/api_metrics.rs
@@ -248,13 +248,13 @@ impl MetricsAPI {
         datadog::Error<GetMetricMetadataError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_metric_metadata";
+        let local_operation_id = "v1.get_metric_metadata";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/metrics/{metric_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -355,7 +355,7 @@ impl MetricsAPI {
         datadog::Error<ListActiveMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_active_metrics";
+        let local_operation_id = "v1.list_active_metrics";
 
         // unbox and build optional parameters
         let host = params.host;
@@ -365,7 +365,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -479,13 +479,13 @@ impl MetricsAPI {
         datadog::Error<ListMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_metrics";
+        let local_operation_id = "v1.list_metrics";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -590,13 +590,13 @@ impl MetricsAPI {
         datadog::Error<QueryMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.query_metrics";
+        let local_operation_id = "v1.query_metrics";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/query",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -706,7 +706,7 @@ impl MetricsAPI {
         datadog::Error<SubmitDistributionPointsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.submit_distribution_points";
+        let local_operation_id = "v1.submit_distribution_points";
 
         // unbox and build optional parameters
         let content_encoding = params.content_encoding;
@@ -715,7 +715,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/distribution_points",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -887,7 +887,7 @@ impl MetricsAPI {
         datadog::Error<SubmitMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.submit_metrics";
+        let local_operation_id = "v1.submit_metrics";
 
         // unbox and build optional parameters
         let content_encoding = params.content_encoding;
@@ -896,7 +896,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/series",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1051,13 +1051,13 @@ impl MetricsAPI {
         datadog::Error<UpdateMetricMetadataError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_metric_metadata";
+        let local_operation_id = "v1.update_metric_metadata";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/metrics/{metric_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_monitors.rs
+++ b/src/datadogV1/api/api_monitors.rs
@@ -439,13 +439,13 @@ impl MonitorsAPI {
         datadog::Error<CheckCanDeleteMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.check_can_delete_monitor";
+        let local_operation_id = "v1.check_can_delete_monitor";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/can_delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1022,13 +1022,13 @@ impl MonitorsAPI {
         datadog::Error<CreateMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_monitor";
+        let local_operation_id = "v1.create_monitor";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/monitor",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1174,7 +1174,7 @@ impl MonitorsAPI {
         datadog::Error<DeleteMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_monitor";
+        let local_operation_id = "v1.delete_monitor";
 
         // unbox and build optional parameters
         let force = params.force;
@@ -1183,7 +1183,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/{monitor_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             monitor_id = monitor_id
         );
         let mut local_req_builder =
@@ -1288,7 +1288,7 @@ impl MonitorsAPI {
         datadog::Error<GetMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_monitor";
+        let local_operation_id = "v1.get_monitor";
 
         // unbox and build optional parameters
         let group_states = params.group_states;
@@ -1299,7 +1299,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/{monitor_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             monitor_id = monitor_id
         );
         let mut local_req_builder =
@@ -1441,7 +1441,7 @@ impl MonitorsAPI {
         datadog::Error<ListMonitorsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_monitors";
+        let local_operation_id = "v1.list_monitors";
 
         // unbox and build optional parameters
         let group_states = params.group_states;
@@ -1457,7 +1457,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/monitor",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1589,7 +1589,7 @@ impl MonitorsAPI {
         datadog::Error<SearchMonitorGroupsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.search_monitor_groups";
+        let local_operation_id = "v1.search_monitor_groups";
 
         // unbox and build optional parameters
         let query = params.query;
@@ -1601,7 +1601,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/groups/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1718,7 +1718,7 @@ impl MonitorsAPI {
         datadog::Error<SearchMonitorsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.search_monitors";
+        let local_operation_id = "v1.search_monitors";
 
         // unbox and build optional parameters
         let query = params.query;
@@ -1730,7 +1730,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1848,13 +1848,13 @@ impl MonitorsAPI {
         datadog::Error<UpdateMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_monitor";
+        let local_operation_id = "v1.update_monitor";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/{monitor_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             monitor_id = monitor_id
         );
         let mut local_req_builder =
@@ -2011,13 +2011,13 @@ impl MonitorsAPI {
         datadog::Error<ValidateExistingMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.validate_existing_monitor";
+        let local_operation_id = "v1.validate_existing_monitor";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/{monitor_id}/validate",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             monitor_id = monitor_id
         );
         let mut local_req_builder =
@@ -2171,13 +2171,13 @@ impl MonitorsAPI {
         datadog::Error<ValidateMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.validate_monitor";
+        let local_operation_id = "v1.validate_monitor";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/monitor/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV1/api/api_notebooks.rs
+++ b/src/datadogV1/api/api_notebooks.rs
@@ -236,13 +236,13 @@ impl NotebooksAPI {
         datadog::Error<CreateNotebookError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_notebook";
+        let local_operation_id = "v1.create_notebook";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/notebooks",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -376,13 +376,13 @@ impl NotebooksAPI {
         notebook_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteNotebookError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_notebook";
+        let local_operation_id = "v1.delete_notebook";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/notebooks/{notebook_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             notebook_id = notebook_id
         );
         let mut local_req_builder =
@@ -475,13 +475,13 @@ impl NotebooksAPI {
         datadog::Error<GetNotebookError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_notebook";
+        let local_operation_id = "v1.get_notebook";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/notebooks/{notebook_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             notebook_id = notebook_id
         );
         let mut local_req_builder =
@@ -619,7 +619,7 @@ impl NotebooksAPI {
         datadog::Error<ListNotebooksError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_notebooks";
+        let local_operation_id = "v1.list_notebooks";
 
         // unbox and build optional parameters
         let author_handle = params.author_handle;
@@ -637,7 +637,7 @@ impl NotebooksAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/notebooks",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -779,13 +779,13 @@ impl NotebooksAPI {
         datadog::Error<UpdateNotebookError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_notebook";
+        let local_operation_id = "v1.update_notebook";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/notebooks/{notebook_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             notebook_id = notebook_id
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_organizations.rs
+++ b/src/datadogV1/api/api_organizations.rs
@@ -181,13 +181,13 @@ impl OrganizationsAPI {
         datadog::Error<CreateChildOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_child_org";
+        let local_operation_id = "v1.create_child_org";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/org",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -334,13 +334,13 @@ impl OrganizationsAPI {
         datadog::Error<DowngradeOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.downgrade_org";
+        let local_operation_id = "v1.downgrade_org";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/org/{public_id}/downgrade",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -439,13 +439,13 @@ impl OrganizationsAPI {
         datadog::Error<GetOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_org";
+        let local_operation_id = "v1.get_org";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/org/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -543,13 +543,13 @@ impl OrganizationsAPI {
         datadog::Error<ListOrgsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_orgs";
+        let local_operation_id = "v1.list_orgs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/org",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -649,13 +649,13 @@ impl OrganizationsAPI {
         datadog::Error<UpdateOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_org";
+        let local_operation_id = "v1.update_org";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/org/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -816,13 +816,13 @@ impl OrganizationsAPI {
         datadog::Error<UploadIdPForOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.upload_idp_for_org";
+        let local_operation_id = "v1.upload_idp_for_org";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/org/{public_id}/idp_metadata",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_pager_duty_integration.rs
+++ b/src/datadogV1/api/api_pager_duty_integration.rs
@@ -151,13 +151,13 @@ impl PagerDutyIntegrationAPI {
         datadog::Error<CreatePagerDutyIntegrationServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_pager_duty_integration_service";
+        let local_operation_id = "v1.create_pager_duty_integration_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/pagerduty/configuration/services",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -296,13 +296,13 @@ impl PagerDutyIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeletePagerDutyIntegrationServiceError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_pager_duty_integration_service";
+        let local_operation_id = "v1.delete_pager_duty_integration_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/pagerduty/configuration/services/{service_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_name = datadog::urlencode(service_name)
         );
         let mut local_req_builder =
@@ -401,13 +401,13 @@ impl PagerDutyIntegrationAPI {
         datadog::Error<GetPagerDutyIntegrationServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_pager_duty_integration_service";
+        let local_operation_id = "v1.get_pager_duty_integration_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/pagerduty/configuration/services/{service_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_name = datadog::urlencode(service_name)
         );
         let mut local_req_builder =
@@ -502,13 +502,13 @@ impl PagerDutyIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdatePagerDutyIntegrationServiceError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_pager_duty_integration_service";
+        let local_operation_id = "v1.update_pager_duty_integration_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/pagerduty/configuration/services/{service_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_name = datadog::urlencode(service_name)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_security_monitoring.rs
+++ b/src/datadogV1/api/api_security_monitoring.rs
@@ -144,13 +144,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<AddSecurityMonitoringSignalToIncidentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.add_security_monitoring_signal_to_incident";
+        let local_operation_id = "v1.add_security_monitoring_signal_to_incident";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/security_analytics/signals/{signal_id}/add_to_incident",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -305,13 +305,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<EditSecurityMonitoringSignalAssigneeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.edit_security_monitoring_signal_assignee";
+        let local_operation_id = "v1.edit_security_monitoring_signal_assignee";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/security_analytics/signals/{signal_id}/assignee",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -466,13 +466,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<EditSecurityMonitoringSignalStateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.edit_security_monitoring_signal_state";
+        let local_operation_id = "v1.edit_security_monitoring_signal_state";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/security_analytics/signals/{signal_id}/state",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_service_checks.rs
+++ b/src/datadogV1/api/api_service_checks.rs
@@ -147,13 +147,13 @@ impl ServiceChecksAPI {
         datadog::Error<SubmitServiceCheckError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.submit_service_check";
+        let local_operation_id = "v1.submit_service_check";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/check_run",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV1/api/api_service_level_objective_corrections.rs
+++ b/src/datadogV1/api/api_service_level_objective_corrections.rs
@@ -185,13 +185,13 @@ impl ServiceLevelObjectiveCorrectionsAPI {
         datadog::Error<CreateSLOCorrectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_slo_correction";
+        let local_operation_id = "v1.create_slo_correction";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/correction",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -329,13 +329,13 @@ impl ServiceLevelObjectiveCorrectionsAPI {
         slo_correction_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSLOCorrectionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_slo_correction";
+        let local_operation_id = "v1.delete_slo_correction";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/correction/{slo_correction_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_correction_id = datadog::urlencode(slo_correction_id)
         );
         let mut local_req_builder =
@@ -432,13 +432,13 @@ impl ServiceLevelObjectiveCorrectionsAPI {
         datadog::Error<GetSLOCorrectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_slo_correction";
+        let local_operation_id = "v1.get_slo_correction";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/correction/{slo_correction_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_correction_id = datadog::urlencode(slo_correction_id)
         );
         let mut local_req_builder =
@@ -578,7 +578,7 @@ impl ServiceLevelObjectiveCorrectionsAPI {
         datadog::Error<ListSLOCorrectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_slo_correction";
+        let local_operation_id = "v1.list_slo_correction";
 
         // unbox and build optional parameters
         let offset = params.offset;
@@ -588,7 +588,7 @@ impl ServiceLevelObjectiveCorrectionsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/slo/correction",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -704,13 +704,13 @@ impl ServiceLevelObjectiveCorrectionsAPI {
         datadog::Error<UpdateSLOCorrectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_slo_correction";
+        let local_operation_id = "v1.update_slo_correction";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/correction/{slo_correction_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_correction_id = datadog::urlencode(slo_correction_id)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_service_level_objectives.rs
+++ b/src/datadogV1/api/api_service_level_objectives.rs
@@ -355,13 +355,13 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<CheckCanDeleteSLOError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.check_can_delete_slo";
+        let local_operation_id = "v1.check_can_delete_slo";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/can_delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -462,13 +462,13 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<CreateSLOError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_slo";
+        let local_operation_id = "v1.create_slo";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -619,7 +619,7 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<DeleteSLOError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_slo";
+        let local_operation_id = "v1.delete_slo";
 
         // unbox and build optional parameters
         let force = params.force;
@@ -628,7 +628,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/slo/{slo_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_id = datadog::urlencode(slo_id)
         );
         let mut local_req_builder =
@@ -742,13 +742,13 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<DeleteSLOTimeframeInBulkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_slo_timeframe_in_bulk";
+        let local_operation_id = "v1.delete_slo_timeframe_in_bulk";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/bulk_delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -896,7 +896,7 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<GetSLOError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_slo";
+        let local_operation_id = "v1.get_slo";
 
         // unbox and build optional parameters
         let with_configured_alert_ids = params.with_configured_alert_ids;
@@ -905,7 +905,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/slo/{slo_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_id = datadog::urlencode(slo_id)
         );
         let mut local_req_builder =
@@ -1010,13 +1010,13 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<GetSLOCorrectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_slo_corrections";
+        let local_operation_id = "v1.get_slo_corrections";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/{slo_id}/corrections",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_id = datadog::urlencode(slo_id)
         );
         let mut local_req_builder =
@@ -1140,7 +1140,7 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<GetSLOHistoryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_slo_history";
+        let local_operation_id = "v1.get_slo_history";
 
         // unbox and build optional parameters
         let target = params.target;
@@ -1150,7 +1150,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/slo/{slo_id}/history",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_id = datadog::urlencode(slo_id)
         );
         let mut local_req_builder =
@@ -1298,7 +1298,7 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<ListSLOsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_slos";
+        let local_operation_id = "v1.list_slos";
 
         // unbox and build optional parameters
         let ids = params.ids;
@@ -1312,7 +1312,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/slo",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1432,7 +1432,7 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<SearchSLOError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.search_slo";
+        let local_operation_id = "v1.search_slo";
 
         // unbox and build optional parameters
         let query = params.query;
@@ -1444,7 +1444,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/slo/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1560,13 +1560,13 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<UpdateSLOError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_slo";
+        let local_operation_id = "v1.update_slo";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/slo/{slo_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_id = datadog::urlencode(slo_id)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_slack_integration.rs
+++ b/src/datadogV1/api/api_slack_integration.rs
@@ -161,13 +161,13 @@ impl SlackIntegrationAPI {
         datadog::Error<CreateSlackIntegrationChannelError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_slack_integration_channel";
+        let local_operation_id = "v1.create_slack_integration_channel";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/slack/configuration/accounts/{account_name}/channels",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_name = datadog::urlencode(account_name)
         );
         let mut local_req_builder =
@@ -322,13 +322,13 @@ impl SlackIntegrationAPI {
         datadog::Error<GetSlackIntegrationChannelError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_slack_integration_channel";
+        let local_operation_id = "v1.get_slack_integration_channel";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/slack/configuration/accounts/{account_name}/channels/{channel_name}",
-            local_configuration.get_operation_host(operation_id), account_name=
+            local_configuration.get_operation_host(local_operation_id), account_name=
             datadog::urlencode(account_name)
             , channel_name=
             datadog::urlencode(channel_name)
@@ -436,13 +436,13 @@ impl SlackIntegrationAPI {
         datadog::Error<GetSlackIntegrationChannelsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_slack_integration_channels";
+        let local_operation_id = "v1.get_slack_integration_channels";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/slack/configuration/accounts/{account_name}/channels",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_name = datadog::urlencode(account_name)
         );
         let mut local_req_builder =
@@ -537,13 +537,13 @@ impl SlackIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RemoveSlackIntegrationChannelError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v1.remove_slack_integration_channel";
+        let local_operation_id = "v1.remove_slack_integration_channel";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/slack/configuration/accounts/{account_name}/channels/{channel_name}",
-            local_configuration.get_operation_host(operation_id), account_name=
+            local_configuration.get_operation_host(local_operation_id), account_name=
             datadog::urlencode(account_name)
             , channel_name=
             datadog::urlencode(channel_name)
@@ -648,13 +648,13 @@ impl SlackIntegrationAPI {
         datadog::Error<UpdateSlackIntegrationChannelError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_slack_integration_channel";
+        let local_operation_id = "v1.update_slack_integration_channel";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/slack/configuration/accounts/{account_name}/channels/{channel_name}",
-            local_configuration.get_operation_host(operation_id), account_name=
+            local_configuration.get_operation_host(local_operation_id), account_name=
             datadog::urlencode(account_name)
             , channel_name=
             datadog::urlencode(channel_name)

--- a/src/datadogV1/api/api_snapshots.rs
+++ b/src/datadogV1/api/api_snapshots.rs
@@ -181,7 +181,7 @@ impl SnapshotsAPI {
         datadog::Error<GetGraphSnapshotError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_graph_snapshot";
+        let local_operation_id = "v1.get_graph_snapshot";
 
         // unbox and build optional parameters
         let metric_query = params.metric_query;
@@ -195,7 +195,7 @@ impl SnapshotsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/graph/snapshot",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV1/api/api_synthetics.rs
+++ b/src/datadogV1/api/api_synthetics.rs
@@ -531,13 +531,13 @@ impl SyntheticsAPI {
         datadog::Error<CreateGlobalVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_global_variable";
+        let local_operation_id = "v1.create_global_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/variables",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -688,13 +688,13 @@ impl SyntheticsAPI {
         datadog::Error<CreatePrivateLocationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_private_location";
+        let local_operation_id = "v1.create_private_location";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/private-locations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -844,13 +844,13 @@ impl SyntheticsAPI {
         datadog::Error<CreateSyntheticsAPITestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_synthetics_api_test";
+        let local_operation_id = "v1.create_synthetics_api_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/api",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1001,13 +1001,13 @@ impl SyntheticsAPI {
         datadog::Error<CreateSyntheticsBrowserTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_synthetics_browser_test";
+        let local_operation_id = "v1.create_synthetics_browser_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/browser",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1159,13 +1159,13 @@ impl SyntheticsAPI {
         datadog::Error<CreateSyntheticsMobileTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_synthetics_mobile_test";
+        let local_operation_id = "v1.create_synthetics_mobile_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/mobile",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1303,13 +1303,13 @@ impl SyntheticsAPI {
         variable_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteGlobalVariableError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_global_variable";
+        let local_operation_id = "v1.delete_global_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/variables/{variable_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             variable_id = datadog::urlencode(variable_id)
         );
         let mut local_req_builder =
@@ -1394,13 +1394,13 @@ impl SyntheticsAPI {
         location_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeletePrivateLocationError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_private_location";
+        let local_operation_id = "v1.delete_private_location";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/private-locations/{location_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             location_id = datadog::urlencode(location_id)
         );
         let mut local_req_builder =
@@ -1496,13 +1496,13 @@ impl SyntheticsAPI {
         datadog::Error<DeleteTestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_tests";
+        let local_operation_id = "v1.delete_tests";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1655,13 +1655,13 @@ impl SyntheticsAPI {
         datadog::Error<EditGlobalVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.edit_global_variable";
+        let local_operation_id = "v1.edit_global_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/variables/{variable_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             variable_id = datadog::urlencode(variable_id)
         );
         let mut local_req_builder =
@@ -1809,13 +1809,13 @@ impl SyntheticsAPI {
         datadog::Error<FetchUptimesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.fetch_uptimes";
+        let local_operation_id = "v1.fetch_uptimes";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/uptimes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1962,13 +1962,13 @@ impl SyntheticsAPI {
         datadog::Error<GetAPITestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_api_test";
+        let local_operation_id = "v1.get_api_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/api/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2076,7 +2076,7 @@ impl SyntheticsAPI {
         datadog::Error<GetAPITestLatestResultsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_api_test_latest_results";
+        let local_operation_id = "v1.get_api_test_latest_results";
 
         // unbox and build optional parameters
         let from_ts = params.from_ts;
@@ -2087,7 +2087,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/{public_id}/results",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2210,13 +2210,13 @@ impl SyntheticsAPI {
         datadog::Error<GetAPITestResultError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_api_test_result";
+        let local_operation_id = "v1.get_api_test_result";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/{public_id}/results/{result_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id),
             result_id = datadog::urlencode(result_id)
         );
@@ -2320,13 +2320,13 @@ impl SyntheticsAPI {
         datadog::Error<GetBrowserTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_browser_test";
+        let local_operation_id = "v1.get_browser_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/browser/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2436,7 +2436,7 @@ impl SyntheticsAPI {
         datadog::Error<GetBrowserTestLatestResultsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_browser_test_latest_results";
+        let local_operation_id = "v1.get_browser_test_latest_results";
 
         // unbox and build optional parameters
         let from_ts = params.from_ts;
@@ -2447,7 +2447,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/browser/{public_id}/results",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2570,13 +2570,13 @@ impl SyntheticsAPI {
         datadog::Error<GetBrowserTestResultError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_browser_test_result";
+        let local_operation_id = "v1.get_browser_test_result";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/browser/{public_id}/results/{result_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id),
             result_id = datadog::urlencode(result_id)
         );
@@ -2680,13 +2680,13 @@ impl SyntheticsAPI {
         datadog::Error<GetGlobalVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_global_variable";
+        let local_operation_id = "v1.get_global_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/variables/{variable_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             variable_id = datadog::urlencode(variable_id)
         );
         let mut local_req_builder =
@@ -2789,13 +2789,13 @@ impl SyntheticsAPI {
         datadog::Error<GetMobileTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_mobile_test";
+        let local_operation_id = "v1.get_mobile_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/mobile/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2898,13 +2898,13 @@ impl SyntheticsAPI {
         datadog::Error<GetPrivateLocationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_private_location";
+        let local_operation_id = "v1.get_private_location";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/private-locations/{location_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             location_id = datadog::urlencode(location_id)
         );
         let mut local_req_builder =
@@ -3007,13 +3007,13 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsCIBatchError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_synthetics_ci_batch";
+        let local_operation_id = "v1.get_synthetics_ci_batch";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/ci/batch/{batch_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             batch_id = datadog::urlencode(batch_id)
         );
         let mut local_req_builder =
@@ -3111,13 +3111,13 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsDefaultLocationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_synthetics_default_locations";
+        let local_operation_id = "v1.get_synthetics_default_locations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/settings/default_locations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3217,13 +3217,13 @@ impl SyntheticsAPI {
         datadog::Error<GetTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_test";
+        let local_operation_id = "v1.get_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -3323,13 +3323,13 @@ impl SyntheticsAPI {
         datadog::Error<ListGlobalVariablesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_global_variables";
+        let local_operation_id = "v1.list_global_variables";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/variables",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3430,13 +3430,13 @@ impl SyntheticsAPI {
         datadog::Error<ListLocationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_locations";
+        let local_operation_id = "v1.list_locations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/locations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3572,7 +3572,7 @@ impl SyntheticsAPI {
         datadog::Error<ListTestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_tests";
+        let local_operation_id = "v1.list_tests";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -3582,7 +3582,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3692,13 +3692,13 @@ impl SyntheticsAPI {
         datadog::Error<PatchTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.patch_test";
+        let local_operation_id = "v1.patch_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -3847,7 +3847,7 @@ impl SyntheticsAPI {
         datadog::Error<SearchTestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.search_tests";
+        let local_operation_id = "v1.search_tests";
 
         // unbox and build optional parameters
         let text = params.text;
@@ -3861,7 +3861,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3987,13 +3987,13 @@ impl SyntheticsAPI {
         datadog::Error<TriggerCITestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.trigger_ci_tests";
+        let local_operation_id = "v1.trigger_ci_tests";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/trigger/ci",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4142,13 +4142,13 @@ impl SyntheticsAPI {
         datadog::Error<TriggerTestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.trigger_tests";
+        let local_operation_id = "v1.trigger_tests";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/trigger",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4296,13 +4296,13 @@ impl SyntheticsAPI {
         datadog::Error<UpdateAPITestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_api_test";
+        let local_operation_id = "v1.update_api_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/api/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -4456,13 +4456,13 @@ impl SyntheticsAPI {
         datadog::Error<UpdateBrowserTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_browser_test";
+        let local_operation_id = "v1.update_browser_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/browser/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -4615,13 +4615,13 @@ impl SyntheticsAPI {
         datadog::Error<UpdateMobileTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_mobile_test";
+        let local_operation_id = "v1.update_mobile_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/mobile/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -4776,13 +4776,13 @@ impl SyntheticsAPI {
         datadog::Error<UpdatePrivateLocationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_private_location";
+        let local_operation_id = "v1.update_private_location";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/private-locations/{location_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             location_id = datadog::urlencode(location_id)
         );
         let mut local_req_builder =
@@ -4931,13 +4931,13 @@ impl SyntheticsAPI {
         body: crate::datadogV1::model::SyntheticsUpdateTestPauseStatusPayload,
     ) -> Result<datadog::ResponseContent<bool>, datadog::Error<UpdateTestPauseStatusError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_test_pause_status";
+        let local_operation_id = "v1.update_test_pause_status";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/synthetics/tests/{public_id}/status",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_tags.rs
+++ b/src/datadogV1/api/api_tags.rs
@@ -251,7 +251,7 @@ impl TagsAPI {
         datadog::Error<CreateHostTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_host_tags";
+        let local_operation_id = "v1.create_host_tags";
 
         // unbox and build optional parameters
         let source = params.source;
@@ -260,7 +260,7 @@ impl TagsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/tags/hosts/{host_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             host_name = datadog::urlencode(host_name)
         );
         let mut local_req_builder =
@@ -406,7 +406,7 @@ impl TagsAPI {
         params: DeleteHostTagsOptionalParams,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteHostTagsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_host_tags";
+        let local_operation_id = "v1.delete_host_tags";
 
         // unbox and build optional parameters
         let source = params.source;
@@ -415,7 +415,7 @@ impl TagsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/tags/hosts/{host_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             host_name = datadog::urlencode(host_name)
         );
         let mut local_req_builder =
@@ -515,7 +515,7 @@ impl TagsAPI {
         datadog::Error<GetHostTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_host_tags";
+        let local_operation_id = "v1.get_host_tags";
 
         // unbox and build optional parameters
         let source = params.source;
@@ -524,7 +524,7 @@ impl TagsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/tags/hosts/{host_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             host_name = datadog::urlencode(host_name)
         );
         let mut local_req_builder =
@@ -626,7 +626,7 @@ impl TagsAPI {
         datadog::Error<ListHostTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_host_tags";
+        let local_operation_id = "v1.list_host_tags";
 
         // unbox and build optional parameters
         let source = params.source;
@@ -635,7 +635,7 @@ impl TagsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/tags/hosts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -745,7 +745,7 @@ impl TagsAPI {
         datadog::Error<UpdateHostTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_host_tags";
+        let local_operation_id = "v1.update_host_tags";
 
         // unbox and build optional parameters
         let source = params.source;
@@ -754,7 +754,7 @@ impl TagsAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/tags/hosts/{host_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             host_name = datadog::urlencode(host_name)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_usage_metering.rs
+++ b/src/datadogV1/api/api_usage_metering.rs
@@ -1189,7 +1189,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetDailyCustomReportsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_daily_custom_reports";
+        let local_operation_id = "v1.get_daily_custom_reports";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1201,7 +1201,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/daily_custom_reports",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1358,7 +1358,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetHourlyUsageAttributionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_hourly_usage_attribution";
+        let local_operation_id = "v1.get_hourly_usage_attribution";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -1370,7 +1370,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/hourly-attribution",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1506,7 +1506,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetIncidentManagementError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_incident_management";
+        let local_operation_id = "v1.get_incident_management";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -1515,7 +1515,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/incident-management",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1638,7 +1638,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetIngestedSpansError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_ingested_spans";
+        let local_operation_id = "v1.get_ingested_spans";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -1647,7 +1647,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/ingested-spans",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1767,7 +1767,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetMonthlyCustomReportsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_monthly_custom_reports";
+        let local_operation_id = "v1.get_monthly_custom_reports";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1779,7 +1779,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/monthly_custom_reports",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1936,7 +1936,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetMonthlyUsageAttributionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_monthly_usage_attribution";
+        let local_operation_id = "v1.get_monthly_usage_attribution";
 
         // unbox and build optional parameters
         let end_month = params.end_month;
@@ -1950,7 +1950,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/monthly-attribution",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2094,13 +2094,13 @@ impl UsageMeteringAPI {
         datadog::Error<GetSpecifiedDailyCustomReportsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_specified_daily_custom_reports";
+        let local_operation_id = "v1.get_specified_daily_custom_reports";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/daily_custom_reports/{report_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             report_id = datadog::urlencode(report_id)
         );
         let mut local_req_builder =
@@ -2213,13 +2213,13 @@ impl UsageMeteringAPI {
         datadog::Error<GetSpecifiedMonthlyCustomReportsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_specified_monthly_custom_reports";
+        let local_operation_id = "v1.get_specified_monthly_custom_reports";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/monthly_custom_reports/{report_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             report_id = datadog::urlencode(report_id)
         );
         let mut local_req_builder =
@@ -2332,7 +2332,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageAnalyzedLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_analyzed_logs";
+        let local_operation_id = "v1.get_usage_analyzed_logs";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -2341,7 +2341,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/analyzed_logs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2464,7 +2464,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageAuditLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_audit_logs";
+        let local_operation_id = "v1.get_usage_audit_logs";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -2473,7 +2473,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/audit_logs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2593,7 +2593,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageBillableSummaryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_billable_summary";
+        let local_operation_id = "v1.get_usage_billable_summary";
 
         // unbox and build optional parameters
         let month = params.month;
@@ -2603,7 +2603,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/billable-summary",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2723,7 +2723,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageCIAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_ci_app";
+        let local_operation_id = "v1.get_usage_ci_app";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -2732,7 +2732,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/ci-app",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2849,7 +2849,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageCWSError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_cws";
+        let local_operation_id = "v1.get_usage_cws";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -2858,7 +2858,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/cws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2981,7 +2981,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageCloudSecurityPostureManagementError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_cloud_security_posture_management";
+        let local_operation_id = "v1.get_usage_cloud_security_posture_management";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -2990,7 +2990,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/cspm",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3108,7 +3108,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageDBMError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_dbm";
+        let local_operation_id = "v1.get_usage_dbm";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -3117,7 +3117,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/dbm",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3236,7 +3236,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageFargateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_fargate";
+        let local_operation_id = "v1.get_usage_fargate";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -3245,7 +3245,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/fargate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3363,7 +3363,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageHostsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_hosts";
+        let local_operation_id = "v1.get_usage_hosts";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -3372,7 +3372,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/hosts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3495,7 +3495,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageIndexedSpansError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_indexed_spans";
+        let local_operation_id = "v1.get_usage_indexed_spans";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -3504,7 +3504,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/indexed-spans",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3627,7 +3627,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageInternetOfThingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_internet_of_things";
+        let local_operation_id = "v1.get_usage_internet_of_things";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -3636,7 +3636,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/iot",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3753,7 +3753,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageLambdaError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_lambda";
+        let local_operation_id = "v1.get_usage_lambda";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -3762,7 +3762,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/aws_lambda",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3879,7 +3879,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_logs";
+        let local_operation_id = "v1.get_usage_logs";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -3888,7 +3888,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/logs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4007,7 +4007,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageLogsByIndexError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_logs_by_index";
+        let local_operation_id = "v1.get_usage_logs_by_index";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4017,7 +4017,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/logs_by_index",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4145,7 +4145,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageLogsByRetentionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_logs_by_retention";
+        let local_operation_id = "v1.get_usage_logs_by_retention";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4154,7 +4154,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/logs-by-retention",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4277,7 +4277,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageNetworkFlowsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_network_flows";
+        let local_operation_id = "v1.get_usage_network_flows";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4286,7 +4286,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/network_flows",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4409,7 +4409,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageNetworkHostsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_network_hosts";
+        let local_operation_id = "v1.get_usage_network_hosts";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4418,7 +4418,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/network_hosts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4541,7 +4541,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageOnlineArchiveError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_online_archive";
+        let local_operation_id = "v1.get_usage_online_archive";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4550,7 +4550,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/online-archive",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4673,7 +4673,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageProfilingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_profiling";
+        let local_operation_id = "v1.get_usage_profiling";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4682,7 +4682,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/profiling",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4805,7 +4805,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageRumSessionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_rum_sessions";
+        let local_operation_id = "v1.get_usage_rum_sessions";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4815,7 +4815,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/rum_sessions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4940,7 +4940,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageRumUnitsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_rum_units";
+        let local_operation_id = "v1.get_usage_rum_units";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -4949,7 +4949,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/rum",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5066,7 +5066,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageSDSError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_sds";
+        let local_operation_id = "v1.get_usage_sds";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -5075,7 +5075,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/sds",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5190,7 +5190,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageSNMPError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_snmp";
+        let local_operation_id = "v1.get_usage_snmp";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -5199,7 +5199,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/snmp",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5334,7 +5334,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageSummaryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_summary";
+        let local_operation_id = "v1.get_usage_summary";
 
         // unbox and build optional parameters
         let end_month = params.end_month;
@@ -5345,7 +5345,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/summary",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5476,7 +5476,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageSyntheticsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_synthetics";
+        let local_operation_id = "v1.get_usage_synthetics";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -5485,7 +5485,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/synthetics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5608,7 +5608,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageSyntheticsAPIError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_synthetics_api";
+        let local_operation_id = "v1.get_usage_synthetics_api";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -5617,7 +5617,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/synthetics_api",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5740,7 +5740,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageSyntheticsBrowserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_synthetics_browser";
+        let local_operation_id = "v1.get_usage_synthetics_browser";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -5749,7 +5749,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/synthetics_browser",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5872,7 +5872,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageTimeseriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_timeseries";
+        let local_operation_id = "v1.get_usage_timeseries";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -5881,7 +5881,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/timeseries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5997,7 +5997,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageTopAvgMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_usage_top_avg_metrics";
+        let local_operation_id = "v1.get_usage_top_avg_metrics";
 
         // unbox and build optional parameters
         let month = params.month;
@@ -6010,7 +6010,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v1/usage/top_avg_metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV1/api/api_users.rs
+++ b/src/datadogV1/api/api_users.rs
@@ -158,13 +158,13 @@ impl UsersAPI {
         datadog::Error<CreateUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_user";
+        let local_operation_id = "v1.create_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/user",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -314,13 +314,13 @@ impl UsersAPI {
         datadog::Error<DisableUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.disable_user";
+        let local_operation_id = "v1.disable_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/user/{user_handle}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_handle = datadog::urlencode(user_handle)
         );
         let mut local_req_builder =
@@ -419,13 +419,13 @@ impl UsersAPI {
         datadog::Error<GetUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_user";
+        let local_operation_id = "v1.get_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/user/{user_handle}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_handle = datadog::urlencode(user_handle)
         );
         let mut local_req_builder =
@@ -520,13 +520,13 @@ impl UsersAPI {
         datadog::Error<ListUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.list_users";
+        let local_operation_id = "v1.list_users";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/user",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -629,13 +629,13 @@ impl UsersAPI {
         datadog::Error<UpdateUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_user";
+        let local_operation_id = "v1.update_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/user/{user_handle}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_handle = datadog::urlencode(user_handle)
         );
         let mut local_req_builder =

--- a/src/datadogV1/api/api_webhooks_integration.rs
+++ b/src/datadogV1/api/api_webhooks_integration.rs
@@ -180,13 +180,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<CreateWebhooksIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_webhooks_integration";
+        let local_operation_id = "v1.create_webhooks_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/webhooks",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -340,13 +340,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<CreateWebhooksIntegrationCustomVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.create_webhooks_integration_custom_variable";
+        let local_operation_id = "v1.create_webhooks_integration_custom_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/custom-variables",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -485,13 +485,13 @@ impl WebhooksIntegrationAPI {
         webhook_name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteWebhooksIntegrationError>> {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_webhooks_integration";
+        let local_operation_id = "v1.delete_webhooks_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/webhooks/{webhook_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             webhook_name = datadog::urlencode(webhook_name)
         );
         let mut local_req_builder =
@@ -579,13 +579,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<DeleteWebhooksIntegrationCustomVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.delete_webhooks_integration_custom_variable";
+        let local_operation_id = "v1.delete_webhooks_integration_custom_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/custom-variables/{custom_variable_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_variable_name = datadog::urlencode(custom_variable_name)
         );
         let mut local_req_builder =
@@ -684,13 +684,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<GetWebhooksIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_webhooks_integration";
+        let local_operation_id = "v1.get_webhooks_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/webhooks/{webhook_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             webhook_name = datadog::urlencode(webhook_name)
         );
         let mut local_req_builder =
@@ -804,13 +804,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<GetWebhooksIntegrationCustomVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.get_webhooks_integration_custom_variable";
+        let local_operation_id = "v1.get_webhooks_integration_custom_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/custom-variables/{custom_variable_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_variable_name = datadog::urlencode(custom_variable_name)
         );
         let mut local_req_builder =
@@ -919,13 +919,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<UpdateWebhooksIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_webhooks_integration";
+        let local_operation_id = "v1.update_webhooks_integration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/webhooks/{webhook_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             webhook_name = datadog::urlencode(webhook_name)
         );
         let mut local_req_builder =
@@ -1082,13 +1082,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<UpdateWebhooksIntegrationCustomVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v1.update_webhooks_integration_custom_variable";
+        let local_operation_id = "v1.update_webhooks_integration_custom_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v1/integration/webhooks/configuration/custom-variables/{custom_variable_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_variable_name = datadog::urlencode(custom_variable_name)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_action_connection.rs
+++ b/src/datadogV2/api/api_action_connection.rs
@@ -209,13 +209,13 @@ impl ActionConnectionAPI {
         datadog::Error<CreateActionConnectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_action_connection";
+        let local_operation_id = "v2.create_action_connection";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions/connections",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -353,13 +353,13 @@ impl ActionConnectionAPI {
         connection_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteActionConnectionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_action_connection";
+        let local_operation_id = "v2.delete_action_connection";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions/connections/{connection_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             connection_id = datadog::urlencode(connection_id)
         );
         let mut local_req_builder =
@@ -458,13 +458,13 @@ impl ActionConnectionAPI {
         datadog::Error<GetActionConnectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_action_connection";
+        let local_operation_id = "v2.get_action_connection";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions/connections/{connection_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             connection_id = datadog::urlencode(connection_id)
         );
         let mut local_req_builder =
@@ -570,13 +570,13 @@ impl ActionConnectionAPI {
         datadog::Error<GetAppKeyRegistrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_app_key_registration";
+        let local_operation_id = "v2.get_app_key_registration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions/app_key_registrations/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -679,7 +679,7 @@ impl ActionConnectionAPI {
         datadog::Error<ListAppKeyRegistrationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_app_key_registrations";
+        let local_operation_id = "v2.list_app_key_registrations";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -689,7 +689,7 @@ impl ActionConnectionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/actions/app_key_registrations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -798,13 +798,13 @@ impl ActionConnectionAPI {
         datadog::Error<RegisterAppKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.register_app_key";
+        let local_operation_id = "v2.register_app_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions/app_key_registrations/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -893,13 +893,13 @@ impl ActionConnectionAPI {
         app_key_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnregisterAppKeyError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unregister_app_key";
+        let local_operation_id = "v2.unregister_app_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions/app_key_registrations/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -1000,13 +1000,13 @@ impl ActionConnectionAPI {
         datadog::Error<UpdateActionConnectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_action_connection";
+        let local_operation_id = "v2.update_action_connection";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions/connections/{connection_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             connection_id = datadog::urlencode(connection_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_actions_datastores.rs
+++ b/src/datadogV2/api/api_actions_datastores.rs
@@ -254,13 +254,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<BulkDeleteDatastoreItemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_delete_datastore_items";
+        let local_operation_id = "v2.bulk_delete_datastore_items";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}/items/bulk",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =
@@ -416,13 +416,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<BulkWriteDatastoreItemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_write_datastore_items";
+        let local_operation_id = "v2.bulk_write_datastore_items";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}/items/bulk",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =
@@ -572,13 +572,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<CreateDatastoreError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_datastore";
+        let local_operation_id = "v2.create_datastore";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -713,13 +713,13 @@ impl ActionsDatastoresAPI {
         datastore_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDatastoreError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_datastore";
+        let local_operation_id = "v2.delete_datastore";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =
@@ -820,13 +820,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<DeleteDatastoreItemError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_datastore_item";
+        let local_operation_id = "v2.delete_datastore_item";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}/items",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =
@@ -973,13 +973,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<GetDatastoreError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_datastore";
+        let local_operation_id = "v2.get_datastore";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =
@@ -1082,7 +1082,7 @@ impl ActionsDatastoresAPI {
         datadog::Error<ListDatastoreItemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_datastore_items";
+        let local_operation_id = "v2.list_datastore_items";
 
         // unbox and build optional parameters
         let filter = params.filter;
@@ -1095,7 +1095,7 @@ impl ActionsDatastoresAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}/items",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =
@@ -1214,13 +1214,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<ListDatastoresError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_datastores";
+        let local_operation_id = "v2.list_datastores";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1322,13 +1322,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<UpdateDatastoreError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_datastore";
+        let local_operation_id = "v2.update_datastore";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =
@@ -1479,13 +1479,13 @@ impl ActionsDatastoresAPI {
         datadog::Error<UpdateDatastoreItemError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_datastore_item";
+        let local_operation_id = "v2.update_datastore_item";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/actions-datastores/{datastore_id}/items",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             datastore_id = datadog::urlencode(datastore_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_agentless_scanning.rs
+++ b/src/datadogV2/api/api_agentless_scanning.rs
@@ -263,13 +263,13 @@ impl AgentlessScanningAPI {
         datadog::Error<CreateAwsOnDemandTaskError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_aws_on_demand_task";
+        let local_operation_id = "v2.create_aws_on_demand_task";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/ondemand/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -418,13 +418,13 @@ impl AgentlessScanningAPI {
         datadog::Error<CreateAwsScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_aws_scan_options";
+        let local_operation_id = "v2.create_aws_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -573,13 +573,13 @@ impl AgentlessScanningAPI {
         datadog::Error<CreateAzureScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_azure_scan_options";
+        let local_operation_id = "v2.create_azure_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/azure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -725,13 +725,13 @@ impl AgentlessScanningAPI {
         datadog::Error<CreateGcpScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_gcp_scan_options";
+        let local_operation_id = "v2.create_gcp_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/gcp",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -867,13 +867,13 @@ impl AgentlessScanningAPI {
         account_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAwsScanOptionsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_aws_scan_options";
+        let local_operation_id = "v2.delete_aws_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/aws/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -958,13 +958,13 @@ impl AgentlessScanningAPI {
         subscription_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAzureScanOptionsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_azure_scan_options";
+        let local_operation_id = "v2.delete_azure_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/azure/{subscription_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             subscription_id = datadog::urlencode(subscription_id)
         );
         let mut local_req_builder =
@@ -1049,13 +1049,13 @@ impl AgentlessScanningAPI {
         project_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteGcpScanOptionsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_gcp_scan_options";
+        let local_operation_id = "v2.delete_gcp_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/gcp/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -1149,13 +1149,13 @@ impl AgentlessScanningAPI {
         datadog::Error<GetAwsOnDemandTaskError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_on_demand_task";
+        let local_operation_id = "v2.get_aws_on_demand_task";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/ondemand/aws/{task_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             task_id = datadog::urlencode(task_id)
         );
         let mut local_req_builder =
@@ -1258,13 +1258,13 @@ impl AgentlessScanningAPI {
         datadog::Error<GetAwsScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_scan_options";
+        let local_operation_id = "v2.get_aws_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/aws/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -1368,13 +1368,13 @@ impl AgentlessScanningAPI {
         datadog::Error<GetAzureScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_azure_scan_options";
+        let local_operation_id = "v2.get_azure_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/azure/{subscription_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             subscription_id = datadog::urlencode(subscription_id)
         );
         let mut local_req_builder =
@@ -1474,13 +1474,13 @@ impl AgentlessScanningAPI {
         datadog::Error<GetGcpScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_gcp_scan_options";
+        let local_operation_id = "v2.get_gcp_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/gcp/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -1579,13 +1579,13 @@ impl AgentlessScanningAPI {
         datadog::Error<ListAwsOnDemandTasksError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_aws_on_demand_tasks";
+        let local_operation_id = "v2.list_aws_on_demand_tasks";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/ondemand/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1685,13 +1685,13 @@ impl AgentlessScanningAPI {
         datadog::Error<ListAwsScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_aws_scan_options";
+        let local_operation_id = "v2.list_aws_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/aws",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1791,13 +1791,13 @@ impl AgentlessScanningAPI {
         datadog::Error<ListAzureScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_azure_scan_options";
+        let local_operation_id = "v2.list_azure_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/azure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1895,13 +1895,13 @@ impl AgentlessScanningAPI {
         datadog::Error<ListGcpScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_gcp_scan_options";
+        let local_operation_id = "v2.list_gcp_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/gcp",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1994,13 +1994,13 @@ impl AgentlessScanningAPI {
         body: crate::datadogV2::model::AwsScanOptionsUpdateRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateAwsScanOptionsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_aws_scan_options";
+        let local_operation_id = "v2.update_aws_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/aws/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -2148,13 +2148,13 @@ impl AgentlessScanningAPI {
         datadog::Error<UpdateAzureScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_azure_scan_options";
+        let local_operation_id = "v2.update_azure_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/azure/{subscription_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             subscription_id = datadog::urlencode(subscription_id)
         );
         let mut local_req_builder =
@@ -2306,13 +2306,13 @@ impl AgentlessScanningAPI {
         datadog::Error<UpdateGcpScanOptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_gcp_scan_options";
+        let local_operation_id = "v2.update_gcp_scan_options";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/agentless_scanning/accounts/gcp/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_annotations.rs
+++ b/src/datadogV2/api/api_annotations.rs
@@ -179,9 +179,9 @@ impl AnnotationsAPI {
         datadog::Error<CreateAnnotationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_annotation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_annotation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_annotation' is not enabled".to_string(),
@@ -193,7 +193,7 @@ impl AnnotationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/annotation",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -330,9 +330,9 @@ impl AnnotationsAPI {
         annotation_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAnnotationError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_annotation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_annotation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_annotation' is not enabled".to_string(),
@@ -344,7 +344,7 @@ impl AnnotationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/annotation/{annotation_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             annotation_id = datadog::urlencode(annotation_id.to_string())
         );
         let mut local_req_builder =
@@ -451,9 +451,9 @@ impl AnnotationsAPI {
         datadog::Error<GetPageAnnotationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_page_annotations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_page_annotations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_page_annotations' is not enabled".to_string(),
@@ -465,7 +465,7 @@ impl AnnotationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/annotation/page/{page_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id)
         );
         let mut local_req_builder =
@@ -578,9 +578,9 @@ impl AnnotationsAPI {
         datadog::Error<ListAnnotationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_annotations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_annotations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_annotations' is not enabled".to_string(),
@@ -595,7 +595,7 @@ impl AnnotationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/annotation",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -712,9 +712,9 @@ impl AnnotationsAPI {
         datadog::Error<UpdateAnnotationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_annotation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_annotation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_annotation' is not enabled".to_string(),
@@ -726,7 +726,7 @@ impl AnnotationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/annotation/{annotation_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             annotation_id = datadog::urlencode(annotation_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_api_management.rs
+++ b/src/datadogV2/api/api_api_management.rs
@@ -222,9 +222,9 @@ impl APIManagementAPI {
         datadog::Error<CreateOpenAPIError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_open_api";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_open_api";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_open_api' is not enabled".to_string(),
@@ -239,7 +239,7 @@ impl APIManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/apicatalog/openapi",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -354,9 +354,9 @@ impl APIManagementAPI {
         id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOpenAPIError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_open_api";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_open_api";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_open_api' is not enabled".to_string(),
@@ -368,7 +368,7 @@ impl APIManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/apicatalog/api/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -458,9 +458,9 @@ impl APIManagementAPI {
         id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<Vec<u8>>, datadog::Error<GetOpenAPIError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_open_api";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_open_api";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_open_api' is not enabled".to_string(),
@@ -472,7 +472,7 @@ impl APIManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/apicatalog/api/{id}/openapi",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -564,9 +564,9 @@ impl APIManagementAPI {
         datadog::Error<ListAPIsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_apis";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_apis";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_apis' is not enabled".to_string(),
@@ -583,7 +583,7 @@ impl APIManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/apicatalog/api",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -698,9 +698,9 @@ impl APIManagementAPI {
         datadog::Error<UpdateOpenAPIError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_open_api";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_open_api";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_open_api' is not enabled".to_string(),
@@ -715,7 +715,7 @@ impl APIManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/apicatalog/api/{id}/openapi",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_apm.rs
+++ b/src/datadogV2/api/api_apm.rs
@@ -113,13 +113,13 @@ impl APMAPI {
         datadog::Error<GetServiceListError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_service_list";
+        let local_operation_id = "v2.get_service_list";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/services",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_apm_retention_filters.rs
+++ b/src/datadogV2/api/api_apm_retention_filters.rs
@@ -169,13 +169,13 @@ impl APMRetentionFiltersAPI {
         datadog::Error<CreateApmRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_apm_retention_filter";
+        let local_operation_id = "v2.create_apm_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/retention-filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -317,13 +317,13 @@ impl APMRetentionFiltersAPI {
         filter_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteApmRetentionFilterError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_apm_retention_filter";
+        let local_operation_id = "v2.delete_apm_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/retention-filters/{filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             filter_id = datadog::urlencode(filter_id)
         );
         let mut local_req_builder =
@@ -422,13 +422,13 @@ impl APMRetentionFiltersAPI {
         datadog::Error<GetApmRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_apm_retention_filter";
+        let local_operation_id = "v2.get_apm_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/retention-filters/{filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             filter_id = datadog::urlencode(filter_id)
         );
         let mut local_req_builder =
@@ -529,13 +529,13 @@ impl APMRetentionFiltersAPI {
         datadog::Error<ListApmRetentionFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_apm_retention_filters";
+        let local_operation_id = "v2.list_apm_retention_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/retention-filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -626,13 +626,13 @@ impl APMRetentionFiltersAPI {
         body: crate::datadogV2::model::ReorderRetentionFiltersRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ReorderApmRetentionFiltersError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_apm_retention_filters";
+        let local_operation_id = "v2.reorder_apm_retention_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/retention-filters-execution-order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -783,13 +783,13 @@ impl APMRetentionFiltersAPI {
         datadog::Error<UpdateApmRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_apm_retention_filter";
+        let local_operation_id = "v2.update_apm_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/retention-filters/{filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             filter_id = datadog::urlencode(filter_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_apm_trace.rs
+++ b/src/datadogV2/api/api_apm_trace.rs
@@ -226,9 +226,9 @@ impl APMTraceAPI {
         datadog::Error<GetPrunedTraceByIDError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_pruned_trace_by_id";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_pruned_trace_by_id";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_pruned_trace_by_id' is not enabled".to_string(),
@@ -249,7 +249,7 @@ impl APMTraceAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/pruned_trace/{trace_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             trace_id = datadog::urlencode(trace_id)
         );
         let mut local_req_builder =
@@ -388,9 +388,9 @@ impl APMTraceAPI {
         datadog::Error<GetTraceByIDError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_trace_by_id";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_trace_by_id";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_trace_by_id' is not enabled".to_string(),
@@ -405,7 +405,7 @@ impl APMTraceAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/trace/{trace_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             trace_id = datadog::urlencode(trace_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_app_builder.rs
+++ b/src/datadogV2/api/api_app_builder.rs
@@ -449,13 +449,13 @@ impl AppBuilderAPI {
         datadog::Error<CreateAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_app";
+        let local_operation_id = "v2.create_app";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -607,13 +607,13 @@ impl AppBuilderAPI {
         datadog::Error<CreatePublishRequestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_publish_request";
+        let local_operation_id = "v2.create_publish_request";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/publish-request",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -760,13 +760,13 @@ impl AppBuilderAPI {
         datadog::Error<DeleteAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_app";
+        let local_operation_id = "v2.delete_app";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -864,13 +864,13 @@ impl AppBuilderAPI {
         datadog::Error<DeleteAppsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_apps";
+        let local_operation_id = "v2.delete_apps";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1017,7 +1017,7 @@ impl AppBuilderAPI {
         datadog::Error<GetAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_app";
+        let local_operation_id = "v2.get_app";
 
         // unbox and build optional parameters
         let version = params.version;
@@ -1026,7 +1026,7 @@ impl AppBuilderAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -1129,13 +1129,13 @@ impl AppBuilderAPI {
         datadog::Error<GetBlueprintError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_blueprint";
+        let local_operation_id = "v2.get_blueprint";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/blueprint/{blueprint_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             blueprint_id = datadog::urlencode(blueprint_id.to_string())
         );
         let mut local_req_builder =
@@ -1240,13 +1240,13 @@ impl AppBuilderAPI {
         datadog::Error<GetBlueprintsByIntegrationIdError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_blueprints_by_integration_id";
+        let local_operation_id = "v2.get_blueprints_by_integration_id";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/blueprints/integration-id/{integration_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_id = datadog::urlencode(integration_id)
         );
         let mut local_req_builder =
@@ -1349,13 +1349,13 @@ impl AppBuilderAPI {
         datadog::Error<GetBlueprintsBySlugsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_blueprints_by_slugs";
+        let local_operation_id = "v2.get_blueprints_by_slugs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/blueprints/slugs/{slugs}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slugs = datadog::urlencode(slugs)
         );
         let mut local_req_builder =
@@ -1460,7 +1460,7 @@ impl AppBuilderAPI {
         datadog::Error<ListAppVersionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_app_versions";
+        let local_operation_id = "v2.list_app_versions";
 
         // unbox and build optional parameters
         let limit = params.limit;
@@ -1470,7 +1470,7 @@ impl AppBuilderAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/versions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -1579,7 +1579,7 @@ impl AppBuilderAPI {
         datadog::Error<ListAppsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_apps";
+        let local_operation_id = "v2.list_apps";
 
         // unbox and build optional parameters
         let limit = params.limit;
@@ -1598,7 +1598,7 @@ impl AppBuilderAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1748,7 +1748,7 @@ impl AppBuilderAPI {
         datadog::Error<ListBlueprintsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_blueprints";
+        let local_operation_id = "v2.list_blueprints";
 
         // unbox and build optional parameters
         let limit = params.limit;
@@ -1758,7 +1758,7 @@ impl AppBuilderAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/blueprints",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1865,13 +1865,13 @@ impl AppBuilderAPI {
         datadog::Error<ListTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tags";
+        let local_operation_id = "v2.list_tags";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/tags",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1969,13 +1969,13 @@ impl AppBuilderAPI {
         datadog::Error<PublishAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.publish_app";
+        let local_operation_id = "v2.publish_app";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/deployment",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -2076,13 +2076,13 @@ impl AppBuilderAPI {
         datadog::Error<RevertAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.revert_app";
+        let local_operation_id = "v2.revert_app";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/revert",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -2183,13 +2183,13 @@ impl AppBuilderAPI {
         datadog::Error<UnpublishAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.unpublish_app";
+        let local_operation_id = "v2.unpublish_app";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/deployment",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -2290,13 +2290,13 @@ impl AppBuilderAPI {
         datadog::Error<UpdateAppError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_app";
+        let local_operation_id = "v2.update_app";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -2432,13 +2432,13 @@ impl AppBuilderAPI {
         body: crate::datadogV2::model::UpdateAppFavoriteRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateAppFavoriteError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_app_favorite";
+        let local_operation_id = "v2.update_app_favorite";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/favorite",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -2572,13 +2572,13 @@ impl AppBuilderAPI {
         body: crate::datadogV2::model::UpdateAppSelfServiceRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateAppSelfServiceError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_app_self_service";
+        let local_operation_id = "v2.update_app_self_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/self-service",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -2709,13 +2709,13 @@ impl AppBuilderAPI {
         body: crate::datadogV2::model::UpdateAppTagsRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateAppTagsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_app_tags";
+        let local_operation_id = "v2.update_app_tags";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/tags",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -2851,13 +2851,13 @@ impl AppBuilderAPI {
         body: crate::datadogV2::model::UpdateAppVersionNameRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateAppVersionNameError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_app_version_name";
+        let local_operation_id = "v2.update_app_version_name";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/version-name",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =
@@ -3007,13 +3007,13 @@ impl AppBuilderAPI {
         datadog::Error<UpdateProtectionLevelError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_protection_level";
+        let local_operation_id = "v2.update_protection_level";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/app-builder/apps/{app_id}/protection-level",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_application_security.rs
+++ b/src/datadogV2/api/api_application_security.rs
@@ -252,13 +252,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<CreateApplicationSecurityWafCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_application_security_waf_custom_rule";
+        let local_operation_id = "v2.create_application_security_waf_custom_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/custom_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -419,13 +419,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<CreateApplicationSecurityWafExclusionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_application_security_waf_exclusion_filter";
+        let local_operation_id = "v2.create_application_security_waf_exclusion_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/exclusion_filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -578,13 +578,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<CreateApplicationSecurityWafPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_application_security_waf_policy";
+        let local_operation_id = "v2.create_application_security_waf_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -725,13 +725,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<DeleteApplicationSecurityWafCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_application_security_waf_custom_rule";
+        let local_operation_id = "v2.delete_application_security_waf_custom_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/custom_rules/{custom_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_rule_id = datadog::urlencode(custom_rule_id)
         );
         let mut local_req_builder =
@@ -819,13 +819,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<DeleteApplicationSecurityWafExclusionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_application_security_waf_exclusion_filter";
+        let local_operation_id = "v2.delete_application_security_waf_exclusion_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/exclusion_filters/{exclusion_filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             exclusion_filter_id = datadog::urlencode(exclusion_filter_id)
         );
         let mut local_req_builder =
@@ -911,13 +911,13 @@ impl ApplicationSecurityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteApplicationSecurityWafPolicyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_application_security_waf_policy";
+        let local_operation_id = "v2.delete_application_security_waf_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -1016,13 +1016,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<GetApplicationSecurityWafCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_application_security_waf_custom_rule";
+        let local_operation_id = "v2.get_application_security_waf_custom_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/custom_rules/{custom_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_rule_id = datadog::urlencode(custom_rule_id)
         );
         let mut local_req_builder =
@@ -1131,13 +1131,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<GetApplicationSecurityWafExclusionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_application_security_waf_exclusion_filter";
+        let local_operation_id = "v2.get_application_security_waf_exclusion_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/exclusion_filters/{exclusion_filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             exclusion_filter_id = datadog::urlencode(exclusion_filter_id)
         );
         let mut local_req_builder =
@@ -1244,13 +1244,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<GetApplicationSecurityWafPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_application_security_waf_policy";
+        let local_operation_id = "v2.get_application_security_waf_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -1362,9 +1362,9 @@ impl ApplicationSecurityAPI {
         datadog::Error<GetAsmServiceByNameError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_asm_service_by_name";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_asm_service_by_name";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_asm_service_by_name' is not enabled".to_string(),
@@ -1376,7 +1376,7 @@ impl ApplicationSecurityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/asm/services/{service_filter}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_filter = datadog::urlencode(service_filter)
         );
         let mut local_req_builder =
@@ -1482,13 +1482,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<ListApplicationSecurityWAFCustomRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_application_security_waf_custom_rules";
+        let local_operation_id = "v2.list_application_security_waf_custom_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/custom_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1592,13 +1592,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<ListApplicationSecurityWAFPoliciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_application_security_waf_policies";
+        let local_operation_id = "v2.list_application_security_waf_policies";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1704,13 +1704,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<ListApplicationSecurityWafExclusionFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_application_security_waf_exclusion_filters";
+        let local_operation_id = "v2.list_application_security_waf_exclusion_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/exclusion_filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1820,13 +1820,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<UpdateApplicationSecurityWafCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_application_security_waf_custom_rule";
+        let local_operation_id = "v2.update_application_security_waf_custom_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/custom_rules/{custom_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_rule_id = datadog::urlencode(custom_rule_id)
         );
         let mut local_req_builder =
@@ -1989,13 +1989,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<UpdateApplicationSecurityWafExclusionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_application_security_waf_exclusion_filter";
+        let local_operation_id = "v2.update_application_security_waf_exclusion_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/exclusion_filters/{exclusion_filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             exclusion_filter_id = datadog::urlencode(exclusion_filter_id)
         );
         let mut local_req_builder =
@@ -2153,13 +2153,13 @@ impl ApplicationSecurityAPI {
         datadog::Error<UpdateApplicationSecurityWafPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_application_security_waf_policy";
+        let local_operation_id = "v2.update_application_security_waf_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/asm/waf/policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_audit.rs
+++ b/src/datadogV2/api/api_audit.rs
@@ -240,7 +240,7 @@ impl AuditAPI {
         datadog::Error<ListAuditLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_audit_logs";
+        let local_operation_id = "v2.list_audit_logs";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -254,7 +254,7 @@ impl AuditAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/audit/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -438,7 +438,7 @@ impl AuditAPI {
         datadog::Error<SearchAuditLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_audit_logs";
+        let local_operation_id = "v2.search_audit_logs";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -447,7 +447,7 @@ impl AuditAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/audit/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_authn_mappings.rs
+++ b/src/datadogV2/api/api_authn_mappings.rs
@@ -204,13 +204,13 @@ impl AuthNMappingsAPI {
         datadog::Error<CreateAuthNMappingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_authn_mapping";
+        let local_operation_id = "v2.create_authn_mapping";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/authn_mappings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -348,13 +348,13 @@ impl AuthNMappingsAPI {
         authn_mapping_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAuthNMappingError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_authn_mapping";
+        let local_operation_id = "v2.delete_authn_mapping";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/authn_mappings/{authn_mapping_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             authn_mapping_id = datadog::urlencode(authn_mapping_id)
         );
         let mut local_req_builder =
@@ -451,13 +451,13 @@ impl AuthNMappingsAPI {
         datadog::Error<GetAuthNMappingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_authn_mapping";
+        let local_operation_id = "v2.get_authn_mapping";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/authn_mappings/{authn_mapping_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             authn_mapping_id = datadog::urlencode(authn_mapping_id)
         );
         let mut local_req_builder =
@@ -560,7 +560,7 @@ impl AuthNMappingsAPI {
         datadog::Error<ListAuthNMappingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_authn_mappings";
+        let local_operation_id = "v2.list_authn_mappings";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -573,7 +573,7 @@ impl AuthNMappingsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/authn_mappings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -701,13 +701,13 @@ impl AuthNMappingsAPI {
         datadog::Error<UpdateAuthNMappingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_authn_mapping";
+        let local_operation_id = "v2.update_authn_mapping";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/authn_mappings/{authn_mapping_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             authn_mapping_id = datadog::urlencode(authn_mapping_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_aws_integration.rs
+++ b/src/datadogV2/api/api_aws_integration.rs
@@ -295,13 +295,13 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateAWSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_aws_account";
+        let local_operation_id = "v2.create_aws_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -457,9 +457,9 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateAWSAccountCCMConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_aws_account_ccm_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_aws_account_ccm_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_aws_account_ccm_config' is not enabled".to_string(),
@@ -471,7 +471,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}/ccm_config",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -624,13 +624,13 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateAWSEventBridgeSourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_aws_event_bridge_source";
+        let local_operation_id = "v2.create_aws_event_bridge_source";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/event_bridge",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -777,13 +777,13 @@ impl AWSIntegrationAPI {
         datadog::Error<CreateNewAWSExternalIDError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_new_aws_external_id";
+        let local_operation_id = "v2.create_new_aws_external_id";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/generate_new_external_id",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -874,13 +874,13 @@ impl AWSIntegrationAPI {
         aws_account_config_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAWSAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_aws_account";
+        let local_operation_id = "v2.delete_aws_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -967,9 +967,9 @@ impl AWSIntegrationAPI {
         aws_account_config_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAWSAccountCCMConfigError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_aws_account_ccm_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_aws_account_ccm_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_aws_account_ccm_config' is not enabled".to_string(),
@@ -981,7 +981,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}/ccm_config",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -1080,13 +1080,13 @@ impl AWSIntegrationAPI {
         datadog::Error<DeleteAWSEventBridgeSourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_aws_event_bridge_source";
+        let local_operation_id = "v2.delete_aws_event_bridge_source";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/event_bridge",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1236,13 +1236,13 @@ impl AWSIntegrationAPI {
         datadog::Error<GetAWSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_account";
+        let local_operation_id = "v2.get_aws_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -1350,9 +1350,9 @@ impl AWSIntegrationAPI {
         datadog::Error<GetAWSAccountCCMConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_account_ccm_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_aws_account_ccm_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_aws_account_ccm_config' is not enabled".to_string(),
@@ -1364,7 +1364,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}/ccm_config",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -1468,13 +1468,13 @@ impl AWSIntegrationAPI {
         datadog::Error<GetAWSIntegrationIAMPermissionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_integration_iam_permissions";
+        let local_operation_id = "v2.get_aws_integration_iam_permissions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/iam_permissions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1578,13 +1578,13 @@ impl AWSIntegrationAPI {
         datadog::Error<GetAWSIntegrationIAMPermissionsResourceCollectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_integration_iam_permissions_resource_collection";
+        let local_operation_id = "v2.get_aws_integration_iam_permissions_resource_collection";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/iam_permissions/resource_collection",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1688,13 +1688,13 @@ impl AWSIntegrationAPI {
         datadog::Error<GetAWSIntegrationIAMPermissionsStandardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_integration_iam_permissions_standard";
+        let local_operation_id = "v2.get_aws_integration_iam_permissions_standard";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/iam_permissions/standard",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1800,9 +1800,9 @@ impl AWSIntegrationAPI {
         datadog::Error<GetAWSMetricNameFilterPreviewError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_metric_name_filter_preview";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_aws_metric_name_filter_preview";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_aws_metric_name_filter_preview' is not enabled".to_string(),
@@ -1814,7 +1814,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}/metric_name_filter_preview",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -1915,7 +1915,7 @@ impl AWSIntegrationAPI {
         datadog::Error<ListAWSAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_aws_accounts";
+        let local_operation_id = "v2.list_aws_accounts";
 
         // unbox and build optional parameters
         let aws_account_id = params.aws_account_id;
@@ -1924,7 +1924,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2029,13 +2029,13 @@ impl AWSIntegrationAPI {
         datadog::Error<ListAWSEventBridgeSourcesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_aws_event_bridge_sources";
+        let local_operation_id = "v2.list_aws_event_bridge_sources";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/event_bridge",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2135,13 +2135,13 @@ impl AWSIntegrationAPI {
         datadog::Error<ListAWSNamespacesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_aws_namespaces";
+        let local_operation_id = "v2.list_aws_namespaces";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/available_namespaces",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2250,9 +2250,9 @@ impl AWSIntegrationAPI {
         datadog::Error<PreviewAWSMetricNameFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.preview_aws_metric_name_filter";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.preview_aws_metric_name_filter";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.preview_aws_metric_name_filter' is not enabled".to_string(),
@@ -2264,7 +2264,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}/metric_name_filter_preview",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -2417,13 +2417,13 @@ impl AWSIntegrationAPI {
         datadog::Error<UpdateAWSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_aws_account";
+        let local_operation_id = "v2.update_aws_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -2580,9 +2580,9 @@ impl AWSIntegrationAPI {
         datadog::Error<UpdateAWSAccountCCMConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_aws_account_ccm_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_aws_account_ccm_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_aws_account_ccm_config' is not enabled".to_string(),
@@ -2594,7 +2594,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/accounts/{aws_account_config_id}/ccm_config",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aws_account_config_id = datadog::urlencode(aws_account_config_id)
         );
         let mut local_req_builder =
@@ -2746,9 +2746,9 @@ impl AWSIntegrationAPI {
         datadog::Error<ValidateAWSCCMConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_awsccm_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.validate_awsccm_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.validate_awsccm_config' is not enabled".to_string(),
@@ -2760,7 +2760,7 @@ impl AWSIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/validate_ccm_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_aws_logs_integration.rs
+++ b/src/datadogV2/api/api_aws_logs_integration.rs
@@ -117,13 +117,13 @@ impl AWSLogsIntegrationAPI {
         datadog::Error<ListAWSLogsServicesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_aws_logs_services";
+        let local_operation_id = "v2.list_aws_logs_services";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/aws/logs/services",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_bits_ai.rs
+++ b/src/datadogV2/api/api_bits_ai.rs
@@ -175,9 +175,9 @@ impl BitsAIAPI {
         datadog::Error<GetInvestigationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_investigation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_investigation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_investigation' is not enabled".to_string(),
@@ -189,7 +189,7 @@ impl BitsAIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/bits-ai/investigations/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -328,9 +328,9 @@ impl BitsAIAPI {
         datadog::Error<ListInvestigationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_investigations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_investigations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_investigations' is not enabled".to_string(),
@@ -347,7 +347,7 @@ impl BitsAIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/bits-ai/investigations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -462,9 +462,9 @@ impl BitsAIAPI {
         datadog::Error<TriggerInvestigationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.trigger_investigation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.trigger_investigation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.trigger_investigation' is not enabled".to_string(),
@@ -476,7 +476,7 @@ impl BitsAIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/bits-ai/investigations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_case_management.rs
+++ b/src/datadogV2/api/api_case_management.rs
@@ -773,13 +773,13 @@ impl CaseManagementAPI {
         datadog::Error<AddCaseInsightsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_case_insights";
+        let local_operation_id = "v2.add_case_insights";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/insights",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -925,13 +925,13 @@ impl CaseManagementAPI {
         datadog::Error<AggregateCasesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.aggregate_cases";
+        let local_operation_id = "v2.aggregate_cases";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1079,13 +1079,13 @@ impl CaseManagementAPI {
         datadog::Error<ArchiveCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.archive_case";
+        let local_operation_id = "v2.archive_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/archive",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -1231,13 +1231,13 @@ impl CaseManagementAPI {
         datadog::Error<AssignCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.assign_case";
+        let local_operation_id = "v2.assign_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/assign",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -1370,13 +1370,13 @@ impl CaseManagementAPI {
         body: crate::datadogV2::model::CaseBulkUpdateRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<BulkUpdateCasesError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_update_cases";
+        let local_operation_id = "v2.bulk_update_cases";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/bulk",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1517,13 +1517,13 @@ impl CaseManagementAPI {
         datadog::Error<CommentCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.comment_case";
+        let local_operation_id = "v2.comment_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/comment",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -1668,7 +1668,7 @@ impl CaseManagementAPI {
         datadog::Error<CountCasesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.count_cases";
+        let local_operation_id = "v2.count_cases";
 
         // unbox and build optional parameters
         let query_filter = params.query_filter;
@@ -1679,7 +1679,7 @@ impl CaseManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cases/count",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1789,13 +1789,13 @@ impl CaseManagementAPI {
         datadog::Error<CreateCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case";
+        let local_operation_id = "v2.create_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1946,13 +1946,13 @@ impl CaseManagementAPI {
         datadog::Error<CreateCaseAutomationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case_automation_rule";
+        let local_operation_id = "v2.create_case_automation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -2093,13 +2093,13 @@ impl CaseManagementAPI {
         body: crate::datadogV2::model::JiraIssueCreateRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateCaseJiraIssueError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case_jira_issue";
+        let local_operation_id = "v2.create_case_jira_issue";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/relationships/jira_issues",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -2240,13 +2240,13 @@ impl CaseManagementAPI {
         datadog::Error<CreateCaseLinkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case_link";
+        let local_operation_id = "v2.create_case_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/link",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2385,13 +2385,13 @@ impl CaseManagementAPI {
         body: crate::datadogV2::model::NotebookCreateRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateCaseNotebookError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case_notebook";
+        let local_operation_id = "v2.create_case_notebook";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/relationships/notebook",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -2525,13 +2525,13 @@ impl CaseManagementAPI {
         body: crate::datadogV2::model::ServiceNowTicketCreateRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateCaseServiceNowTicketError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case_service_now_ticket";
+        let local_operation_id = "v2.create_case_service_now_ticket";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/relationships/servicenow_tickets",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -2672,13 +2672,13 @@ impl CaseManagementAPI {
         datadog::Error<CreateCaseViewError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case_view";
+        let local_operation_id = "v2.create_case_view";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/views",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2826,13 +2826,13 @@ impl CaseManagementAPI {
         datadog::Error<CreateMaintenanceWindowError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_maintenance_window";
+        let local_operation_id = "v2.create_maintenance_window";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/maintenance_windows",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2978,13 +2978,13 @@ impl CaseManagementAPI {
         datadog::Error<CreateProjectError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_project";
+        let local_operation_id = "v2.create_project";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3136,13 +3136,13 @@ impl CaseManagementAPI {
         datadog::Error<CreateProjectNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_project_notification_rule";
+        let local_operation_id = "v2.create_project_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/notification_rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -3283,13 +3283,13 @@ impl CaseManagementAPI {
         rule_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCaseAutomationRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_case_automation_rule";
+        let local_operation_id = "v2.delete_case_automation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -3377,13 +3377,13 @@ impl CaseManagementAPI {
         cell_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCaseCommentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_case_comment";
+        let local_operation_id = "v2.delete_case_comment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/comment/{cell_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id),
             cell_id = datadog::urlencode(cell_id)
         );
@@ -3483,13 +3483,13 @@ impl CaseManagementAPI {
         datadog::Error<DeleteCaseCustomAttributeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_case_custom_attribute";
+        let local_operation_id = "v2.delete_case_custom_attribute";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/custom_attributes/{custom_attribute_key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id),
             custom_attribute_key = datadog::urlencode(custom_attribute_key)
         );
@@ -3577,13 +3577,13 @@ impl CaseManagementAPI {
         link_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCaseLinkError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_case_link";
+        let local_operation_id = "v2.delete_case_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/link/{link_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             link_id = datadog::urlencode(link_id)
         );
         let mut local_req_builder =
@@ -3665,13 +3665,13 @@ impl CaseManagementAPI {
         view_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCaseViewError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_case_view";
+        let local_operation_id = "v2.delete_case_view";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/views/{view_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             view_id = datadog::urlencode(view_id)
         );
         let mut local_req_builder =
@@ -3756,13 +3756,13 @@ impl CaseManagementAPI {
         maintenance_window_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteMaintenanceWindowError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_maintenance_window";
+        let local_operation_id = "v2.delete_maintenance_window";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/maintenance_windows/{maintenance_window_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             maintenance_window_id = datadog::urlencode(maintenance_window_id)
         );
         let mut local_req_builder =
@@ -3844,13 +3844,13 @@ impl CaseManagementAPI {
         project_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteProjectError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_project";
+        let local_operation_id = "v2.delete_project";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -3938,13 +3938,13 @@ impl CaseManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteProjectNotificationRuleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_project_notification_rule";
+        let local_operation_id = "v2.delete_project_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/notification_rules/{notification_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             notification_rule_id = datadog::urlencode(notification_rule_id)
         );
@@ -4046,13 +4046,13 @@ impl CaseManagementAPI {
         datadog::Error<DisableCaseAutomationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.disable_case_automation_rule";
+        let local_operation_id = "v2.disable_case_automation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/rules/{rule_id}/disable",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -4161,13 +4161,13 @@ impl CaseManagementAPI {
         datadog::Error<EnableCaseAutomationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.enable_case_automation_rule";
+        let local_operation_id = "v2.enable_case_automation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/rules/{rule_id}/enable",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -4257,13 +4257,13 @@ impl CaseManagementAPI {
         project_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<FavoriteCaseProjectError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.favorite_case_project";
+        let local_operation_id = "v2.favorite_case_project";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/favorites",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -4356,13 +4356,13 @@ impl CaseManagementAPI {
         datadog::Error<GetCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_case";
+        let local_operation_id = "v2.get_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -4467,13 +4467,13 @@ impl CaseManagementAPI {
         datadog::Error<GetCaseAutomationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_case_automation_rule";
+        let local_operation_id = "v2.get_case_automation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -4574,13 +4574,13 @@ impl CaseManagementAPI {
         datadog::Error<GetCaseViewError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_case_view";
+        let local_operation_id = "v2.get_case_view";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/views/{view_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             view_id = datadog::urlencode(view_id)
         );
         let mut local_req_builder =
@@ -4678,13 +4678,13 @@ impl CaseManagementAPI {
         datadog::Error<GetProjectError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_project";
+        let local_operation_id = "v2.get_project";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -4787,13 +4787,13 @@ impl CaseManagementAPI {
         datadog::Error<GetProjectNotificationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_project_notification_rules";
+        let local_operation_id = "v2.get_project_notification_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/notification_rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -4891,13 +4891,13 @@ impl CaseManagementAPI {
         datadog::Error<GetProjectsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_projects";
+        let local_operation_id = "v2.get_projects";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4996,13 +4996,13 @@ impl CaseManagementAPI {
         datadog::Error<LinkIncidentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.link_incident";
+        let local_operation_id = "v2.link_incident";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/relationships/incidents",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -5140,13 +5140,13 @@ impl CaseManagementAPI {
         body: crate::datadogV2::model::JiraIssueLinkRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<LinkJiraIssueToCaseError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.link_jira_issue_to_case";
+        let local_operation_id = "v2.link_jira_issue_to_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/relationships/jira_issues",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -5292,13 +5292,13 @@ impl CaseManagementAPI {
         datadog::Error<ListCaseAutomationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_case_automation_rules";
+        let local_operation_id = "v2.list_case_automation_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -5406,7 +5406,7 @@ impl CaseManagementAPI {
         datadog::Error<ListCaseLinksError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_case_links";
+        let local_operation_id = "v2.list_case_links";
 
         // unbox and build optional parameters
         let relationship = params.relationship;
@@ -5415,7 +5415,7 @@ impl CaseManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cases/link",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5526,7 +5526,7 @@ impl CaseManagementAPI {
         datadog::Error<ListCaseTimelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_case_timeline";
+        let local_operation_id = "v2.list_case_timeline";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -5537,7 +5537,7 @@ impl CaseManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/timelines",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -5650,13 +5650,13 @@ impl CaseManagementAPI {
         datadog::Error<ListCaseViewsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_case_views";
+        let local_operation_id = "v2.list_case_views";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/views",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5757,13 +5757,13 @@ impl CaseManagementAPI {
         datadog::Error<ListCaseWatchersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_case_watchers";
+        let local_operation_id = "v2.list_case_watchers";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/watchers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -5864,13 +5864,13 @@ impl CaseManagementAPI {
         datadog::Error<ListMaintenanceWindowsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_maintenance_windows";
+        let local_operation_id = "v2.list_maintenance_windows";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/maintenance_windows",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5970,13 +5970,13 @@ impl CaseManagementAPI {
         datadog::Error<ListUserCaseProjectFavoritesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_user_case_project_favorites";
+        let local_operation_id = "v2.list_user_case_project_favorites";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/favorites",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6080,13 +6080,13 @@ impl CaseManagementAPI {
         datadog::Error<MoveCaseToProjectError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.move_case_to_project";
+        let local_operation_id = "v2.move_case_to_project";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/relationships/project",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -6237,13 +6237,13 @@ impl CaseManagementAPI {
         datadog::Error<RemoveCaseInsightsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_case_insights";
+        let local_operation_id = "v2.remove_case_insights";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/insights",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -6420,7 +6420,7 @@ impl CaseManagementAPI {
         datadog::Error<SearchCasesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_cases";
+        let local_operation_id = "v2.search_cases";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -6433,7 +6433,7 @@ impl CaseManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cases",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6552,13 +6552,13 @@ impl CaseManagementAPI {
         datadog::Error<UnarchiveCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.unarchive_case";
+        let local_operation_id = "v2.unarchive_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/unarchive",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -6705,13 +6705,13 @@ impl CaseManagementAPI {
         datadog::Error<UnassignCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.unassign_case";
+        let local_operation_id = "v2.unassign_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/unassign",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -6847,13 +6847,13 @@ impl CaseManagementAPI {
         project_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnfavoriteCaseProjectError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unfavorite_case_project";
+        let local_operation_id = "v2.unfavorite_case_project";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/favorites",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -6935,13 +6935,13 @@ impl CaseManagementAPI {
         case_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnlinkJiraIssueError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unlink_jira_issue";
+        let local_operation_id = "v2.unlink_jira_issue";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/relationships/jira_issues",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -7025,13 +7025,13 @@ impl CaseManagementAPI {
         user_uuid: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnwatchCaseError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unwatch_case";
+        let local_operation_id = "v2.unwatch_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/watchers/{user_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id),
             user_uuid = datadog::urlencode(user_uuid)
         );
@@ -7126,13 +7126,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateAttributesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_attributes";
+        let local_operation_id = "v2.update_attributes";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/attributes",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -7287,13 +7287,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateCaseAutomationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_automation_rule";
+        let local_operation_id = "v2.update_case_automation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -7437,13 +7437,13 @@ impl CaseManagementAPI {
         body: crate::datadogV2::model::CaseUpdateCommentRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateCaseCommentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_comment";
+        let local_operation_id = "v2.update_case_comment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/comment/{cell_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id),
             cell_id = datadog::urlencode(cell_id)
         );
@@ -7592,13 +7592,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateCaseCustomAttributeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_custom_attribute";
+        let local_operation_id = "v2.update_case_custom_attribute";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/custom_attributes/{custom_attribute_key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id),
             custom_attribute_key = datadog::urlencode(custom_attribute_key)
         );
@@ -7750,13 +7750,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateCaseDescriptionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_description";
+        let local_operation_id = "v2.update_case_description";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/description",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -7906,13 +7906,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateCaseDueDateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_due_date";
+        let local_operation_id = "v2.update_case_due_date";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/due_date",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -8063,13 +8063,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateCaseResolvedReasonError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_resolved_reason";
+        let local_operation_id = "v2.update_case_resolved_reason";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/resolved_reason",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -8216,13 +8216,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateCaseTitleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_title";
+        let local_operation_id = "v2.update_case_title";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/title",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -8370,13 +8370,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateCaseViewError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_view";
+        let local_operation_id = "v2.update_case_view";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/views/{view_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             view_id = datadog::urlencode(view_id)
         );
         let mut local_req_builder =
@@ -8530,13 +8530,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateMaintenanceWindowError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_maintenance_window";
+        let local_operation_id = "v2.update_maintenance_window";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/maintenance_windows/{maintenance_window_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             maintenance_window_id = datadog::urlencode(maintenance_window_id)
         );
         let mut local_req_builder =
@@ -8685,13 +8685,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdatePriorityError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_priority";
+        let local_operation_id = "v2.update_priority";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/priority",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -8838,13 +8838,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateProjectError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_project";
+        let local_operation_id = "v2.update_project";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -8986,13 +8986,13 @@ impl CaseManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateProjectNotificationRuleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_project_notification_rule";
+        let local_operation_id = "v2.update_project_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/projects/{project_id}/notification_rules/{notification_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             notification_rule_id = datadog::urlencode(notification_rule_id)
         );
@@ -9135,13 +9135,13 @@ impl CaseManagementAPI {
         datadog::Error<UpdateStatusError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_status";
+        let local_operation_id = "v2.update_status";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/status",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -9276,13 +9276,13 @@ impl CaseManagementAPI {
         user_uuid: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<WatchCaseError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.watch_case";
+        let local_operation_id = "v2.watch_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/{case_id}/watchers/{user_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id),
             user_uuid = datadog::urlencode(user_uuid)
         );

--- a/src/datadogV2/api/api_case_management_attribute.rs
+++ b/src/datadogV2/api/api_case_management_attribute.rs
@@ -160,13 +160,13 @@ impl CaseManagementAttributeAPI {
         datadog::Error<CreateCustomAttributeConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_custom_attribute_config";
+        let local_operation_id = "v2.create_custom_attribute_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types/{case_type_id}/custom_attributes",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_type_id = datadog::urlencode(case_type_id)
         );
         let mut local_req_builder =
@@ -308,13 +308,13 @@ impl CaseManagementAttributeAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCustomAttributeConfigError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_custom_attribute_config";
+        let local_operation_id = "v2.delete_custom_attribute_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types/{case_type_id}/custom_attributes/{custom_attribute_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_type_id = datadog::urlencode(case_type_id),
             custom_attribute_id = datadog::urlencode(custom_attribute_id)
         );
@@ -414,13 +414,13 @@ impl CaseManagementAttributeAPI {
         datadog::Error<GetAllCustomAttributeConfigsByCaseTypeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_all_custom_attribute_configs_by_case_type";
+        let local_operation_id = "v2.get_all_custom_attribute_configs_by_case_type";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types/{case_type_id}/custom_attributes",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_type_id = datadog::urlencode(case_type_id)
         );
         let mut local_req_builder =
@@ -521,13 +521,13 @@ impl CaseManagementAttributeAPI {
         datadog::Error<GetAllCustomAttributesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_all_custom_attributes";
+        let local_operation_id = "v2.get_all_custom_attributes";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types/custom_attributes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -636,13 +636,13 @@ impl CaseManagementAttributeAPI {
         datadog::Error<UpdateCustomAttributeConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_custom_attribute_config";
+        let local_operation_id = "v2.update_custom_attribute_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types/{case_type_id}/custom_attributes/{custom_attribute_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_type_id = datadog::urlencode(case_type_id),
             custom_attribute_id = datadog::urlencode(custom_attribute_id)
         );

--- a/src/datadogV2/api/api_case_management_type.rs
+++ b/src/datadogV2/api/api_case_management_type.rs
@@ -145,13 +145,13 @@ impl CaseManagementTypeAPI {
         datadog::Error<CreateCaseTypeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_case_type";
+        let local_operation_id = "v2.create_case_type";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -285,13 +285,13 @@ impl CaseManagementTypeAPI {
         case_type_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCaseTypeError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_case_type";
+        let local_operation_id = "v2.delete_case_type";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types/{case_type_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_type_id = datadog::urlencode(case_type_id)
         );
         let mut local_req_builder =
@@ -383,13 +383,13 @@ impl CaseManagementTypeAPI {
         datadog::Error<GetAllCaseTypesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_all_case_types";
+        let local_operation_id = "v2.get_all_case_types";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -493,13 +493,13 @@ impl CaseManagementTypeAPI {
         datadog::Error<UpdateCaseTypeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_case_type";
+        let local_operation_id = "v2.update_case_type";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cases/types/{case_type_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_type_id = datadog::urlencode(case_type_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_change_management.rs
+++ b/src/datadogV2/api/api_change_management.rs
@@ -170,9 +170,9 @@ impl ChangeManagementAPI {
         datadog::Error<CreateChangeRequestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_change_request";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_change_request";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_change_request' is not enabled".to_string(),
@@ -184,7 +184,7 @@ impl ChangeManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/change-management/change-request",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -338,9 +338,9 @@ impl ChangeManagementAPI {
         datadog::Error<CreateChangeRequestBranchError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_change_request_branch";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_change_request_branch";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_change_request_branch' is not enabled".to_string(),
@@ -352,7 +352,7 @@ impl ChangeManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/change-management/change-request/{change_request_id}/branch",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             change_request_id = datadog::urlencode(change_request_id)
         );
         let mut local_req_builder =
@@ -507,9 +507,9 @@ impl ChangeManagementAPI {
         datadog::Error<DeleteChangeRequestDecisionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_change_request_decision";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_change_request_decision";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_change_request_decision' is not enabled".to_string(),
@@ -521,7 +521,7 @@ impl ChangeManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/change-management/change-request/{change_request_id}/decisions/{decision_id}",
-            local_configuration.get_operation_host(operation_id), change_request_id=
+            local_configuration.get_operation_host(local_operation_id), change_request_id=
             datadog::urlencode(change_request_id)
             , decision_id=
             datadog::urlencode(decision_id)
@@ -627,9 +627,9 @@ impl ChangeManagementAPI {
         datadog::Error<GetChangeRequestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_change_request";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_change_request";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_change_request' is not enabled".to_string(),
@@ -641,7 +641,7 @@ impl ChangeManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/change-management/change-request/{change_request_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             change_request_id = datadog::urlencode(change_request_id)
         );
         let mut local_req_builder =
@@ -749,9 +749,9 @@ impl ChangeManagementAPI {
         datadog::Error<UpdateChangeRequestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_change_request";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_change_request";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_change_request' is not enabled".to_string(),
@@ -763,7 +763,7 @@ impl ChangeManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/change-management/change-request/{change_request_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             change_request_id = datadog::urlencode(change_request_id)
         );
         let mut local_req_builder =
@@ -920,9 +920,9 @@ impl ChangeManagementAPI {
         datadog::Error<UpdateChangeRequestDecisionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_change_request_decision";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_change_request_decision";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_change_request_decision' is not enabled".to_string(),
@@ -934,7 +934,7 @@ impl ChangeManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/change-management/change-request/{change_request_id}/decisions/{decision_id}",
-            local_configuration.get_operation_host(operation_id), change_request_id=
+            local_configuration.get_operation_host(local_operation_id), change_request_id=
             datadog::urlencode(change_request_id)
             , decision_id=
             datadog::urlencode(decision_id)

--- a/src/datadogV2/api/api_ci_visibility_pipelines.rs
+++ b/src/datadogV2/api/api_ci_visibility_pipelines.rs
@@ -217,13 +217,13 @@ impl CIVisibilityPipelinesAPI {
         datadog::Error<AggregateCIAppPipelineEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.aggregate_ci_app_pipeline_events";
+        let local_operation_id = "v2.aggregate_ci_app_pipeline_events";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/pipelines/analytics/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -383,13 +383,13 @@ impl CIVisibilityPipelinesAPI {
         datadog::Error<CreateCIAppPipelineEventError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_ci_app_pipeline_event";
+        let local_operation_id = "v2.create_ci_app_pipeline_event";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/pipeline",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -577,7 +577,7 @@ impl CIVisibilityPipelinesAPI {
         datadog::Error<ListCIAppPipelineEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ci_app_pipeline_events";
+        let local_operation_id = "v2.list_ci_app_pipeline_events";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -591,7 +591,7 @@ impl CIVisibilityPipelinesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ci/pipelines/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -774,7 +774,7 @@ impl CIVisibilityPipelinesAPI {
         datadog::Error<SearchCIAppPipelineEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_ci_app_pipeline_events";
+        let local_operation_id = "v2.search_ci_app_pipeline_events";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -783,7 +783,7 @@ impl CIVisibilityPipelinesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ci/pipelines/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_ci_visibility_tests.rs
+++ b/src/datadogV2/api/api_ci_visibility_tests.rs
@@ -206,13 +206,13 @@ impl CIVisibilityTestsAPI {
         datadog::Error<AggregateCIAppTestEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.aggregate_ci_app_test_events";
+        let local_operation_id = "v2.aggregate_ci_app_test_events";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/tests/analytics/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -405,7 +405,7 @@ impl CIVisibilityTestsAPI {
         datadog::Error<ListCIAppTestEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ci_app_test_events";
+        let local_operation_id = "v2.list_ci_app_test_events";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -419,7 +419,7 @@ impl CIVisibilityTestsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ci/tests/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -599,7 +599,7 @@ impl CIVisibilityTestsAPI {
         datadog::Error<SearchCIAppTestEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_ci_app_test_events";
+        let local_operation_id = "v2.search_ci_app_test_events";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -608,7 +608,7 @@ impl CIVisibilityTestsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ci/tests/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_cloud_authentication.rs
+++ b/src/datadogV2/api/api_cloud_authentication.rs
@@ -155,9 +155,9 @@ impl CloudAuthenticationAPI {
         datadog::Error<CreateAWSCloudAuthPersonaMappingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_aws_cloud_auth_persona_mapping";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_aws_cloud_auth_persona_mapping";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_aws_cloud_auth_persona_mapping' is not enabled"
@@ -170,7 +170,7 @@ impl CloudAuthenticationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_auth/aws/persona_mapping",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -309,9 +309,9 @@ impl CloudAuthenticationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAWSCloudAuthPersonaMappingError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_aws_cloud_auth_persona_mapping";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_aws_cloud_auth_persona_mapping";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_aws_cloud_auth_persona_mapping' is not enabled"
@@ -324,7 +324,7 @@ impl CloudAuthenticationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_auth/aws/persona_mapping/{persona_mapping_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             persona_mapping_id = datadog::urlencode(persona_mapping_id)
         );
         let mut local_req_builder =
@@ -423,9 +423,9 @@ impl CloudAuthenticationAPI {
         datadog::Error<GetAWSCloudAuthPersonaMappingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aws_cloud_auth_persona_mapping";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_aws_cloud_auth_persona_mapping";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_aws_cloud_auth_persona_mapping' is not enabled".to_string(),
@@ -437,7 +437,7 @@ impl CloudAuthenticationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_auth/aws/persona_mapping/{persona_mapping_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             persona_mapping_id = datadog::urlencode(persona_mapping_id)
         );
         let mut local_req_builder =
@@ -541,9 +541,9 @@ impl CloudAuthenticationAPI {
         datadog::Error<ListAWSCloudAuthPersonaMappingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_aws_cloud_auth_persona_mappings";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_aws_cloud_auth_persona_mappings";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_aws_cloud_auth_persona_mappings' is not enabled"
@@ -556,7 +556,7 @@ impl CloudAuthenticationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_auth/aws/persona_mapping",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_cloud_cost_management.rs
+++ b/src/datadogV2/api/api_cloud_cost_management.rs
@@ -1296,13 +1296,13 @@ impl CloudCostManagementAPI {
         datadog::Error<CreateCostAWSCURConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_cost_awscur_config";
+        let local_operation_id = "v2.create_cost_awscur_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/aws_cur_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1451,13 +1451,13 @@ impl CloudCostManagementAPI {
         datadog::Error<CreateCostAzureUCConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_cost_azure_uc_configs";
+        let local_operation_id = "v2.create_cost_azure_uc_configs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/azure_uc_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1609,13 +1609,13 @@ impl CloudCostManagementAPI {
         datadog::Error<CreateCostGCPUsageCostConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_cost_gcp_usage_cost_config";
+        let local_operation_id = "v2.create_cost_gcp_usage_cost_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/gcp_uc_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1791,13 +1791,13 @@ impl CloudCostManagementAPI {
         datadog::Error<CreateCustomAllocationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_custom_allocation_rule";
+        let local_operation_id = "v2.create_custom_allocation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/arbitrary_rule",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1944,13 +1944,13 @@ impl CloudCostManagementAPI {
         datadog::Error<CreateTagPipelinesRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_tag_pipelines_ruleset";
+        let local_operation_id = "v2.create_tag_pipelines_ruleset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2083,13 +2083,13 @@ impl CloudCostManagementAPI {
         budget_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteBudgetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_budget";
+        let local_operation_id = "v2.delete_budget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget/{budget_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             budget_id = datadog::urlencode(budget_id)
         );
         let mut local_req_builder =
@@ -2173,13 +2173,13 @@ impl CloudCostManagementAPI {
         cloud_account_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCostAWSCURConfigError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_cost_awscur_config";
+        let local_operation_id = "v2.delete_cost_awscur_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/aws_cur_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -2264,13 +2264,13 @@ impl CloudCostManagementAPI {
         cloud_account_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCostAzureUCConfigError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_cost_azure_uc_config";
+        let local_operation_id = "v2.delete_cost_azure_uc_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/azure_uc_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -2356,13 +2356,13 @@ impl CloudCostManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCostGCPUsageCostConfigError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_cost_gcp_usage_cost_config";
+        let local_operation_id = "v2.delete_cost_gcp_usage_cost_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/gcp_uc_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -2450,7 +2450,7 @@ impl CloudCostManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCostTagDescriptionByKeyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_cost_tag_description_by_key";
+        let local_operation_id = "v2.delete_cost_tag_description_by_key";
 
         // unbox and build optional parameters
         let cloud = params.cloud;
@@ -2459,7 +2459,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_descriptions/{tag_key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tag_key = datadog::urlencode(tag_key)
         );
         let mut local_req_builder =
@@ -2549,13 +2549,13 @@ impl CloudCostManagementAPI {
         rule_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCustomAllocationRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_custom_allocation_rule";
+        let local_operation_id = "v2.delete_custom_allocation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/arbitrary_rule/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = rule_id
         );
         let mut local_req_builder =
@@ -2637,13 +2637,13 @@ impl CloudCostManagementAPI {
         file_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCustomCostsFileError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_custom_costs_file";
+        let local_operation_id = "v2.delete_custom_costs_file";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/custom_costs/{file_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             file_id = datadog::urlencode(file_id)
         );
         let mut local_req_builder =
@@ -2725,13 +2725,13 @@ impl CloudCostManagementAPI {
         budget_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCustomForecastError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_custom_forecast";
+        let local_operation_id = "v2.delete_custom_forecast";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget/{budget_id}/custom-forecast",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             budget_id = datadog::urlencode(budget_id)
         );
         let mut local_req_builder =
@@ -2816,13 +2816,13 @@ impl CloudCostManagementAPI {
         ruleset_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTagPipelinesRulesetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_tag_pipelines_ruleset";
+        let local_operation_id = "v2.delete_tag_pipelines_ruleset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment/{ruleset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_id = datadog::urlencode(ruleset_id)
         );
         let mut local_req_builder =
@@ -2921,13 +2921,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GenerateCostTagDescriptionByKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.generate_cost_tag_description_by_key";
+        let local_operation_id = "v2.generate_cost_tag_description_by_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_descriptions/{tag_key}/generate",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tag_key = datadog::urlencode(tag_key)
         );
         let mut local_req_builder =
@@ -3029,7 +3029,7 @@ impl CloudCostManagementAPI {
         datadog::Error<GetBudgetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_budget";
+        let local_operation_id = "v2.get_budget";
 
         // unbox and build optional parameters
         let actual = params.actual;
@@ -3041,7 +3041,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget/{budget_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             budget_id = datadog::urlencode(budget_id)
         );
         let mut local_req_builder =
@@ -3169,9 +3169,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsCommitmentListError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_commitment_list";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_commitment_list";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_commitment_list' is not enabled".to_string(),
@@ -3187,7 +3187,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/commitment-list",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3313,9 +3313,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsCoverageScalarError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_coverage_scalar";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_coverage_scalar";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_coverage_scalar' is not enabled".to_string(),
@@ -3330,7 +3330,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/coverage/scalar",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3454,9 +3454,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsCoverageTimeseriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_coverage_timeseries";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_coverage_timeseries";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_coverage_timeseries' is not enabled"
@@ -3472,7 +3472,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/coverage/timeseries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3599,9 +3599,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsOnDemandHotspotsScalarError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_on_demand_hotspots_scalar";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_on_demand_hotspots_scalar";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_on_demand_hotspots_scalar' is not enabled"
@@ -3617,7 +3617,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/on-demand-hot-spots/scalar",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3740,9 +3740,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsSavingsScalarError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_savings_scalar";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_savings_scalar";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_savings_scalar' is not enabled".to_string(),
@@ -3757,7 +3757,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/savings/scalar",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3881,9 +3881,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsSavingsTimeseriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_savings_timeseries";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_savings_timeseries";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_savings_timeseries' is not enabled".to_string(),
@@ -3898,7 +3898,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/savings/timeseries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4023,9 +4023,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsUtilizationScalarError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_utilization_scalar";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_utilization_scalar";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_utilization_scalar' is not enabled".to_string(),
@@ -4041,7 +4041,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/utilization/scalar",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4170,9 +4170,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCommitmentsUtilizationTimeseriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_commitments_utilization_timeseries";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_commitments_utilization_timeseries";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_commitments_utilization_timeseries' is not enabled"
@@ -4189,7 +4189,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/commitments/utilization/timeseries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4308,13 +4308,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostAWSCURConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_awscur_config";
+        let local_operation_id = "v2.get_cost_awscur_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/aws_cur_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -4420,13 +4420,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostAccountFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_account_filters";
+        let local_operation_id = "v2.get_cost_account_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/account_filters/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -4527,9 +4527,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostAnomalyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_anomaly";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_cost_anomaly";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_cost_anomaly' is not enabled".to_string(),
@@ -4541,7 +4541,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/anomalies/{anomaly_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             anomaly_id = datadog::urlencode(anomaly_id)
         );
         let mut local_req_builder =
@@ -4645,13 +4645,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostAzureUCConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_azure_uc_config";
+        let local_operation_id = "v2.get_cost_azure_uc_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/azure_uc_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -4755,13 +4755,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostGCPUsageCostConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_gcp_usage_cost_config";
+        let local_operation_id = "v2.get_cost_gcp_usage_cost_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/gcp_uc_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -4869,7 +4869,7 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostTagDescriptionByKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_tag_description_by_key";
+        let local_operation_id = "v2.get_cost_tag_description_by_key";
 
         // unbox and build optional parameters
         let filter_cloud = params.filter_cloud;
@@ -4878,7 +4878,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_descriptions/{tag_key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tag_key = datadog::urlencode(tag_key)
         );
         let mut local_req_builder =
@@ -4986,7 +4986,7 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostTagKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_tag_key";
+        let local_operation_id = "v2.get_cost_tag_key";
 
         // unbox and build optional parameters
         let filter_metric = params.filter_metric;
@@ -4996,7 +4996,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_keys/{tag_key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tag_key = datadog::urlencode(tag_key)
         );
         let mut local_req_builder =
@@ -5113,9 +5113,9 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCostTagMetadataCurrencyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_tag_metadata_currency";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_cost_tag_metadata_currency";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_cost_tag_metadata_currency' is not enabled".to_string(),
@@ -5130,7 +5130,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_metadata/currency",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5242,13 +5242,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCustomAllocationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_custom_allocation_rule";
+        let local_operation_id = "v2.get_custom_allocation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/arbitrary_rule/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = rule_id
         );
         let mut local_req_builder =
@@ -5351,13 +5351,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCustomCostsFileError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_custom_costs_file";
+        let local_operation_id = "v2.get_custom_costs_file";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/custom_costs/{file_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             file_id = datadog::urlencode(file_id)
         );
         let mut local_req_builder =
@@ -5460,13 +5460,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetCustomForecastError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_custom_forecast";
+        let local_operation_id = "v2.get_custom_forecast";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget/{budget_id}/custom-forecast",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             budget_id = datadog::urlencode(budget_id)
         );
         let mut local_req_builder =
@@ -5570,13 +5570,13 @@ impl CloudCostManagementAPI {
         datadog::Error<GetTagPipelinesRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tag_pipelines_ruleset";
+        let local_operation_id = "v2.get_tag_pipelines_ruleset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment/{ruleset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_id = datadog::urlencode(ruleset_id)
         );
         let mut local_req_builder =
@@ -5672,13 +5672,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListBudgetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_budgets";
+        let local_operation_id = "v2.list_budgets";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budgets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5775,13 +5775,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostAWSCURConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_awscur_configs";
+        let local_operation_id = "v2.list_cost_awscur_configs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/aws_cur_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5883,9 +5883,9 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostAnomaliesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_anomalies";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_cost_anomalies";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_cost_anomalies' is not enabled".to_string(),
@@ -5910,7 +5910,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/anomalies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6056,13 +6056,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostAzureUCConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_azure_uc_configs";
+        let local_operation_id = "v2.list_cost_azure_uc_configs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/azure_uc_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6162,13 +6162,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostGCPUsageCostConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_gcp_usage_cost_configs";
+        let local_operation_id = "v2.list_cost_gcp_usage_cost_configs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/gcp_uc_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6266,13 +6266,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostOCIConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_oci_configs";
+        let local_operation_id = "v2.list_cost_oci_configs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/oci_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6374,7 +6374,7 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagDescriptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tag_descriptions";
+        let local_operation_id = "v2.list_cost_tag_descriptions";
 
         // unbox and build optional parameters
         let filter_cloud = params.filter_cloud;
@@ -6383,7 +6383,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_descriptions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6495,9 +6495,9 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagKeySourcesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tag_key_sources";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_cost_tag_key_sources";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_cost_tag_key_sources' is not enabled".to_string(),
@@ -6513,7 +6513,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_metadata/tag_sources",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6624,7 +6624,7 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tag_keys";
+        let local_operation_id = "v2.list_cost_tag_keys";
 
         // unbox and build optional parameters
         let filter_metric = params.filter_metric;
@@ -6634,7 +6634,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6752,9 +6752,9 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagMetadataError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tag_metadata";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_cost_tag_metadata";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_cost_tag_metadata' is not enabled".to_string(),
@@ -6772,7 +6772,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_metadata",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6898,9 +6898,9 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagMetadataMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tag_metadata_metrics";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_cost_tag_metadata_metrics";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_cost_tag_metadata_metrics' is not enabled".to_string(),
@@ -6915,7 +6915,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_metadata/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7029,9 +7029,9 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagMetadataMonthsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tag_metadata_months";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_cost_tag_metadata_months";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_cost_tag_metadata_months' is not enabled".to_string(),
@@ -7043,7 +7043,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_metadata/months",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7153,9 +7153,9 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagMetadataOrchestratorsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tag_metadata_orchestrators";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_cost_tag_metadata_orchestrators";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_cost_tag_metadata_orchestrators' is not enabled"
@@ -7171,7 +7171,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_metadata/orchestrators",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7277,7 +7277,7 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCostTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cost_tags";
+        let local_operation_id = "v2.list_cost_tags";
 
         // unbox and build optional parameters
         let filter_metric = params.filter_metric;
@@ -7290,7 +7290,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tags",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7413,13 +7413,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCustomAllocationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_custom_allocation_rules";
+        let local_operation_id = "v2.list_custom_allocation_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/arbitrary_rule",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7522,13 +7522,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCustomAllocationRulesStatusError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_custom_allocation_rules_status";
+        let local_operation_id = "v2.list_custom_allocation_rules_status";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/arbitrary_rule/status",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7630,7 +7630,7 @@ impl CloudCostManagementAPI {
         datadog::Error<ListCustomCostsFilesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_custom_costs_files";
+        let local_operation_id = "v2.list_custom_costs_files";
 
         // unbox and build optional parameters
         let page_number = params.page_number;
@@ -7644,7 +7644,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/custom_costs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7771,13 +7771,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListTagPipelinesRulesetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tag_pipelines_rulesets";
+        let local_operation_id = "v2.list_tag_pipelines_rulesets";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7879,13 +7879,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ListTagPipelinesRulesetsStatusError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tag_pipelines_rulesets_status";
+        let local_operation_id = "v2.list_tag_pipelines_rulesets_status";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment/status",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7989,13 +7989,13 @@ impl CloudCostManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ReorderCustomAllocationRulesError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_custom_allocation_rules";
+        let local_operation_id = "v2.reorder_custom_allocation_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/arbitrary_rule/reorder",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8127,13 +8127,13 @@ impl CloudCostManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ReorderTagPipelinesRulesetsError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_tag_pipelines_rulesets";
+        let local_operation_id = "v2.reorder_tag_pipelines_rulesets";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment/reorder",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8280,9 +8280,9 @@ impl CloudCostManagementAPI {
         datadog::Error<SearchCostRecommendationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_cost_recommendations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.search_cost_recommendations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.search_cost_recommendations' is not enabled".to_string(),
@@ -8298,7 +8298,7 @@ impl CloudCostManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost/recommendations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8461,13 +8461,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpdateCostAWSCURConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_cost_awscur_config";
+        let local_operation_id = "v2.update_cost_awscur_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/aws_cur_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -8622,13 +8622,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpdateCostAccountFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_cost_account_filters";
+        let local_operation_id = "v2.update_cost_account_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/account_filters/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -8783,13 +8783,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpdateCostAzureUCConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_cost_azure_uc_configs";
+        let local_operation_id = "v2.update_cost_azure_uc_configs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/azure_uc_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -8944,13 +8944,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpdateCostGCPUsageCostConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_cost_gcp_usage_cost_config";
+        let local_operation_id = "v2.update_cost_gcp_usage_cost_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/gcp_uc_config/{cloud_account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             cloud_account_id = cloud_account_id
         );
         let mut local_req_builder =
@@ -9131,13 +9131,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpdateCustomAllocationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_custom_allocation_rule";
+        let local_operation_id = "v2.update_custom_allocation_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/arbitrary_rule/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = rule_id
         );
         let mut local_req_builder =
@@ -9290,13 +9290,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpdateTagPipelinesRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_tag_pipelines_ruleset";
+        let local_operation_id = "v2.update_tag_pipelines_ruleset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment/{ruleset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_id = datadog::urlencode(ruleset_id)
         );
         let mut local_req_builder =
@@ -9444,13 +9444,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UploadCustomCostsFileError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upload_custom_costs_file";
+        let local_operation_id = "v2.upload_custom_costs_file";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/custom_costs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -9596,13 +9596,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpsertBudgetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_budget";
+        let local_operation_id = "v2.upsert_budget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -9741,13 +9741,13 @@ impl CloudCostManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpsertCostTagDescriptionByKeyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_cost_tag_description_by_key";
+        let local_operation_id = "v2.upsert_cost_tag_description_by_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/tag_descriptions/{tag_key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tag_key = datadog::urlencode(tag_key)
         );
         let mut local_req_builder =
@@ -9892,13 +9892,13 @@ impl CloudCostManagementAPI {
         datadog::Error<UpsertCustomForecastError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_custom_forecast";
+        let local_operation_id = "v2.upsert_custom_forecast";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget/custom-forecast",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -10047,13 +10047,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ValidateBudgetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_budget";
+        let local_operation_id = "v2.validate_budget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -10196,13 +10196,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ValidateCsvBudgetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_csv_budget";
+        let local_operation_id = "v2.validate_csv_budget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost/budget/csv/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -10290,13 +10290,13 @@ impl CloudCostManagementAPI {
         datadog::Error<ValidateQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_query";
+        let local_operation_id = "v2.validate_query";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/tags/enrichment/validate-query",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_cloud_network_monitoring.rs
+++ b/src/datadogV2/api/api_cloud_network_monitoring.rs
@@ -228,7 +228,7 @@ impl CloudNetworkMonitoringAPI {
         datadog::Error<GetAggregatedConnectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aggregated_connections";
+        let local_operation_id = "v2.get_aggregated_connections";
 
         // unbox and build optional parameters
         let from = params.from;
@@ -242,7 +242,7 @@ impl CloudNetworkMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/network/connections/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -369,7 +369,7 @@ impl CloudNetworkMonitoringAPI {
         datadog::Error<GetAggregatedDnsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_aggregated_dns";
+        let local_operation_id = "v2.get_aggregated_dns";
 
         // unbox and build optional parameters
         let from = params.from;
@@ -383,7 +383,7 @@ impl CloudNetworkMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/network/dns/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_cloudflare_integration.rs
+++ b/src/datadogV2/api/api_cloudflare_integration.rs
@@ -155,13 +155,13 @@ impl CloudflareIntegrationAPI {
         datadog::Error<CreateCloudflareAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_cloudflare_account";
+        let local_operation_id = "v2.create_cloudflare_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/cloudflare/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -299,13 +299,13 @@ impl CloudflareIntegrationAPI {
         account_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCloudflareAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_cloudflare_account";
+        let local_operation_id = "v2.delete_cloudflare_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/cloudflare/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -401,13 +401,13 @@ impl CloudflareIntegrationAPI {
         datadog::Error<GetCloudflareAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cloudflare_account";
+        let local_operation_id = "v2.get_cloudflare_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/cloudflare/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -508,13 +508,13 @@ impl CloudflareIntegrationAPI {
         datadog::Error<ListCloudflareAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cloudflare_accounts";
+        let local_operation_id = "v2.list_cloudflare_accounts";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/cloudflare/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -621,13 +621,13 @@ impl CloudflareIntegrationAPI {
         datadog::Error<UpdateCloudflareAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_cloudflare_account";
+        let local_operation_id = "v2.update_cloudflare_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/cloudflare/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_code_coverage.rs
+++ b/src/datadogV2/api/api_code_coverage.rs
@@ -139,9 +139,9 @@ impl CodeCoverageAPI {
         datadog::Error<GetCodeCoverageBranchSummaryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_code_coverage_branch_summary";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_code_coverage_branch_summary";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_code_coverage_branch_summary' is not enabled".to_string(),
@@ -153,7 +153,7 @@ impl CodeCoverageAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/code-coverage/branch/summary",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -313,9 +313,9 @@ impl CodeCoverageAPI {
         datadog::Error<GetCodeCoverageCommitSummaryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_code_coverage_commit_summary";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_code_coverage_commit_summary";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_code_coverage_commit_summary' is not enabled".to_string(),
@@ -327,7 +327,7 @@ impl CodeCoverageAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/code-coverage/commit/summary",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_compliance.rs
+++ b/src/datadogV2/api/api_compliance.rs
@@ -180,9 +180,9 @@ impl ComplianceAPI {
         datadog::Error<GetRuleBasedViewError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rule_based_view";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_rule_based_view";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_rule_based_view' is not enabled".to_string(),
@@ -203,7 +203,7 @@ impl ComplianceAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/compliance_findings/rule_based_view",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_confluent_cloud.rs
+++ b/src/datadogV2/api/api_confluent_cloud.rs
@@ -195,13 +195,13 @@ impl ConfluentCloudAPI {
         datadog::Error<CreateConfluentAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_confluent_account";
+        let local_operation_id = "v2.create_confluent_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -355,13 +355,13 @@ impl ConfluentCloudAPI {
         datadog::Error<CreateConfluentResourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_confluent_resource";
+        let local_operation_id = "v2.create_confluent_resource";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}/resources",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -500,13 +500,13 @@ impl ConfluentCloudAPI {
         account_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteConfluentAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_confluent_account";
+        let local_operation_id = "v2.delete_confluent_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -593,13 +593,13 @@ impl ConfluentCloudAPI {
         resource_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteConfluentResourceError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_confluent_resource";
+        let local_operation_id = "v2.delete_confluent_resource";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}/resources/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id),
             resource_id = datadog::urlencode(resource_id)
         );
@@ -696,13 +696,13 @@ impl ConfluentCloudAPI {
         datadog::Error<GetConfluentAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_confluent_account";
+        let local_operation_id = "v2.get_confluent_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -810,13 +810,13 @@ impl ConfluentCloudAPI {
         datadog::Error<GetConfluentResourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_confluent_resource";
+        let local_operation_id = "v2.get_confluent_resource";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}/resources/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id),
             resource_id = datadog::urlencode(resource_id)
         );
@@ -918,13 +918,13 @@ impl ConfluentCloudAPI {
         datadog::Error<ListConfluentAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_confluent_account";
+        let local_operation_id = "v2.list_confluent_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1029,13 +1029,13 @@ impl ConfluentCloudAPI {
         datadog::Error<ListConfluentResourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_confluent_resource";
+        let local_operation_id = "v2.list_confluent_resource";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}/resources",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -1143,13 +1143,13 @@ impl ConfluentCloudAPI {
         datadog::Error<UpdateConfluentAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_confluent_account";
+        let local_operation_id = "v2.update_confluent_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -1306,13 +1306,13 @@ impl ConfluentCloudAPI {
         datadog::Error<UpdateConfluentResourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_confluent_resource";
+        let local_operation_id = "v2.update_confluent_resource";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/confluent-cloud/accounts/{account_id}/resources/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id),
             resource_id = datadog::urlencode(resource_id)
         );

--- a/src/datadogV2/api/api_container_images.rs
+++ b/src/datadogV2/api/api_container_images.rs
@@ -205,7 +205,7 @@ impl ContainerImagesAPI {
         datadog::Error<ListContainerImagesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_container_images";
+        let local_operation_id = "v2.list_container_images";
 
         // unbox and build optional parameters
         let filter_tags = params.filter_tags;
@@ -218,7 +218,7 @@ impl ContainerImagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/container_images",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_containers.rs
+++ b/src/datadogV2/api/api_containers.rs
@@ -198,7 +198,7 @@ impl ContainersAPI {
         datadog::Error<ListContainersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_containers";
+        let local_operation_id = "v2.list_containers";
 
         // unbox and build optional parameters
         let filter_tags = params.filter_tags;
@@ -211,7 +211,7 @@ impl ContainersAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/containers",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_csm_agents.rs
+++ b/src/datadogV2/api/api_csm_agents.rs
@@ -201,7 +201,7 @@ impl CSMAgentsAPI {
         datadog::Error<ListAllCSMAgentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_all_csm_agents";
+        let local_operation_id = "v2.list_all_csm_agents";
 
         // unbox and build optional parameters
         let page = params.page;
@@ -213,7 +213,7 @@ impl CSMAgentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/onboarding/agents",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -334,7 +334,7 @@ impl CSMAgentsAPI {
         datadog::Error<ListAllCSMServerlessAgentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_all_csm_serverless_agents";
+        let local_operation_id = "v2.list_all_csm_serverless_agents";
 
         // unbox and build optional parameters
         let page = params.page;
@@ -346,7 +346,7 @@ impl CSMAgentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/onboarding/serverless/agents",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_csm_coverage_analysis.rs
+++ b/src/datadogV2/api/api_csm_coverage_analysis.rs
@@ -142,13 +142,13 @@ impl CSMCoverageAnalysisAPI {
         datadog::Error<GetCSMCloudAccountsCoverageAnalysisError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_csm_cloud_accounts_coverage_analysis";
+        let local_operation_id = "v2.get_csm_cloud_accounts_coverage_analysis";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/csm/onboarding/coverage_analysis/cloud_accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -258,13 +258,13 @@ impl CSMCoverageAnalysisAPI {
         datadog::Error<GetCSMHostsAndContainersCoverageAnalysisError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_csm_hosts_and_containers_coverage_analysis";
+        let local_operation_id = "v2.get_csm_hosts_and_containers_coverage_analysis";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/csm/onboarding/coverage_analysis/hosts_and_containers",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -372,13 +372,13 @@ impl CSMCoverageAnalysisAPI {
         datadog::Error<GetCSMServerlessCoverageAnalysisError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_csm_serverless_coverage_analysis";
+        let local_operation_id = "v2.get_csm_serverless_coverage_analysis";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/csm/onboarding/coverage_analysis/serverless",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_csm_ownership.rs
+++ b/src/datadogV2/api/api_csm_ownership.rs
@@ -295,9 +295,9 @@ impl CSMOwnershipAPI {
         datadog::Error<CreateOwnershipFeedbackError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_ownership_feedback";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_ownership_feedback";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_ownership_feedback' is not enabled".to_string(),
@@ -309,7 +309,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/{resource_id}/{owner_type}/feedback",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id),
             owner_type = datadog::urlencode(owner_type.to_string())
         );
@@ -471,9 +471,9 @@ impl CSMOwnershipAPI {
         datadog::Error<GetOwnershipEvidenceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ownership_evidence";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_ownership_evidence";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_ownership_evidence' is not enabled".to_string(),
@@ -488,7 +488,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/{resource_id}/{owner_type}/evidence",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id),
             owner_type = datadog::urlencode(owner_type.to_string())
         );
@@ -613,9 +613,9 @@ impl CSMOwnershipAPI {
         datadog::Error<GetOwnershipInferenceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ownership_inference";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_ownership_inference";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_ownership_inference' is not enabled".to_string(),
@@ -630,7 +630,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/{resource_id}/{owner_type}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id),
             owner_type = datadog::urlencode(owner_type.to_string())
         );
@@ -742,9 +742,9 @@ impl CSMOwnershipAPI {
         datadog::Error<GetOwnershipSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ownership_settings";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_ownership_settings";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_ownership_settings' is not enabled".to_string(),
@@ -756,7 +756,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/settings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -856,9 +856,9 @@ impl CSMOwnershipAPI {
         datadog::Error<GetOwnershipUntaggedFindingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ownership_untagged_findings";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_ownership_untagged_findings";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_ownership_untagged_findings' is not enabled".to_string(),
@@ -870,7 +870,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/settings/untagged",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -977,9 +977,9 @@ impl CSMOwnershipAPI {
         datadog::Error<ListOwnershipHistoryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ownership_history";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_ownership_history";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_ownership_history' is not enabled".to_string(),
@@ -995,7 +995,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/{resource_id}/history",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id)
         );
         let mut local_req_builder =
@@ -1114,9 +1114,9 @@ impl CSMOwnershipAPI {
         datadog::Error<ListOwnershipHistoryByOwnerTypeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ownership_history_by_owner_type";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_ownership_history_by_owner_type";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_ownership_history_by_owner_type' is not enabled"
@@ -1133,7 +1133,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/{resource_id}/{owner_type}/history",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id),
             owner_type = datadog::urlencode(owner_type.to_string())
         );
@@ -1249,9 +1249,9 @@ impl CSMOwnershipAPI {
         datadog::Error<ListOwnershipInferencesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ownership_inferences";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_ownership_inferences";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_ownership_inferences' is not enabled".to_string(),
@@ -1263,7 +1263,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id)
         );
         let mut local_req_builder =
@@ -1366,9 +1366,9 @@ impl CSMOwnershipAPI {
         datadog::Error<PostOwnershipSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.post_ownership_settings";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.post_ownership_settings";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.post_ownership_settings' is not enabled".to_string(),
@@ -1380,7 +1380,7 @@ impl CSMOwnershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/ownership/settings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_csm_settings.rs
+++ b/src/datadogV2/api/api_csm_settings.rs
@@ -276,9 +276,9 @@ impl CSMSettingsAPI {
         datadog::Error<GetCSMAgentlessHostFacetInfoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_csm_agentless_host_facet_info";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_csm_agentless_host_facet_info";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_csm_agentless_host_facet_info' is not enabled".to_string(),
@@ -294,7 +294,7 @@ impl CSMSettingsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/settings/agentless_hosts/facet_info",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -411,9 +411,9 @@ impl CSMSettingsAPI {
         datadog::Error<GetCSMUnifiedHostFacetInfoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_csm_unified_host_facet_info";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_csm_unified_host_facet_info";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_csm_unified_host_facet_info' is not enabled".to_string(),
@@ -429,7 +429,7 @@ impl CSMSettingsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/settings/hosts/facet_info",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -539,9 +539,9 @@ impl CSMSettingsAPI {
         datadog::Error<ListCSMAgentlessHostFacetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_csm_agentless_host_facets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_csm_agentless_host_facets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_csm_agentless_host_facets' is not enabled".to_string(),
@@ -553,7 +553,7 @@ impl CSMSettingsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/settings/agentless_hosts/facets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -655,9 +655,9 @@ impl CSMSettingsAPI {
         datadog::Error<ListCSMAgentlessHostsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_csm_agentless_hosts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_csm_agentless_hosts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_csm_agentless_hosts' is not enabled".to_string(),
@@ -674,7 +674,7 @@ impl CSMSettingsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/settings/agentless_hosts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -787,9 +787,9 @@ impl CSMSettingsAPI {
         datadog::Error<ListCSMUnifiedHostFacetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_csm_unified_host_facets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_csm_unified_host_facets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_csm_unified_host_facets' is not enabled".to_string(),
@@ -801,7 +801,7 @@ impl CSMSettingsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/settings/hosts/facets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -903,9 +903,9 @@ impl CSMSettingsAPI {
         datadog::Error<ListCSMUnifiedHostsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_csm_unified_hosts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_csm_unified_hosts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_csm_unified_hosts' is not enabled".to_string(),
@@ -922,7 +922,7 @@ impl CSMSettingsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/csm/settings/hosts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_csm_threats.rs
+++ b/src/datadogV2/api/api_csm_threats.rs
@@ -324,13 +324,13 @@ impl CSMThreatsAPI {
         datadog::Error<CreateCSMThreatsAgentPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_csm_threats_agent_policy";
+        let local_operation_id = "v2.create_csm_threats_agent_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/policy",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -487,13 +487,13 @@ impl CSMThreatsAPI {
         datadog::Error<CreateCSMThreatsAgentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_csm_threats_agent_rule";
+        let local_operation_id = "v2.create_csm_threats_agent_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/agent_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -650,13 +650,13 @@ impl CSMThreatsAPI {
         datadog::Error<CreateCloudWorkloadSecurityAgentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_cloud_workload_security_agent_rule";
+        let local_operation_id = "v2.create_cloud_workload_security_agent_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/cloud_workload_security/agent_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -800,13 +800,13 @@ impl CSMThreatsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCSMThreatsAgentPolicyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_csm_threats_agent_policy";
+        let local_operation_id = "v2.delete_csm_threats_agent_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/policy/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -897,7 +897,7 @@ impl CSMThreatsAPI {
         params: DeleteCSMThreatsAgentRuleOptionalParams,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCSMThreatsAgentRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_csm_threats_agent_rule";
+        let local_operation_id = "v2.delete_csm_threats_agent_rule";
 
         // unbox and build optional parameters
         let policy_id = params.policy_id;
@@ -906,7 +906,7 @@ impl CSMThreatsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/agent_rules/{agent_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_rule_id = datadog::urlencode(agent_rule_id)
         );
         let mut local_req_builder =
@@ -1003,13 +1003,13 @@ impl CSMThreatsAPI {
         datadog::Error<DeleteCloudWorkloadSecurityAgentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_cloud_workload_security_agent_rule";
+        let local_operation_id = "v2.delete_cloud_workload_security_agent_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/cloud_workload_security/agent_rules/{agent_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_rule_id = datadog::urlencode(agent_rule_id)
         );
         let mut local_req_builder =
@@ -1106,13 +1106,13 @@ impl CSMThreatsAPI {
     ) -> Result<datadog::ResponseContent<Vec<u8>>, datadog::Error<DownloadCSMThreatsPolicyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.download_csm_threats_policy";
+        let local_operation_id = "v2.download_csm_threats_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/policy/download",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1213,13 +1213,13 @@ impl CSMThreatsAPI {
         datadog::Error<DownloadCloudWorkloadPolicyFileError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.download_cloud_workload_policy_file";
+        let local_operation_id = "v2.download_cloud_workload_policy_file";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/cloud_workload/policy/download",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1321,13 +1321,13 @@ impl CSMThreatsAPI {
         datadog::Error<GetCSMThreatsAgentPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_csm_threats_agent_policy";
+        let local_operation_id = "v2.get_csm_threats_agent_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/policy/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -1440,7 +1440,7 @@ impl CSMThreatsAPI {
         datadog::Error<GetCSMThreatsAgentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_csm_threats_agent_rule";
+        let local_operation_id = "v2.get_csm_threats_agent_rule";
 
         // unbox and build optional parameters
         let policy_id = params.policy_id;
@@ -1449,7 +1449,7 @@ impl CSMThreatsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/agent_rules/{agent_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_rule_id = datadog::urlencode(agent_rule_id)
         );
         let mut local_req_builder =
@@ -1565,13 +1565,13 @@ impl CSMThreatsAPI {
         datadog::Error<GetCloudWorkloadSecurityAgentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cloud_workload_security_agent_rule";
+        let local_operation_id = "v2.get_cloud_workload_security_agent_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/cloud_workload_security/agent_rules/{agent_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_rule_id = datadog::urlencode(agent_rule_id)
         );
         let mut local_req_builder =
@@ -1679,13 +1679,13 @@ impl CSMThreatsAPI {
         datadog::Error<ListCSMThreatsAgentPoliciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_csm_threats_agent_policies";
+        let local_operation_id = "v2.list_csm_threats_agent_policies";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/policy",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1797,7 +1797,7 @@ impl CSMThreatsAPI {
         datadog::Error<ListCSMThreatsAgentRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_csm_threats_agent_rules";
+        let local_operation_id = "v2.list_csm_threats_agent_rules";
 
         // unbox and build optional parameters
         let policy_id = params.policy_id;
@@ -1806,7 +1806,7 @@ impl CSMThreatsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/agent_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1921,13 +1921,13 @@ impl CSMThreatsAPI {
         datadog::Error<ListCloudWorkloadSecurityAgentRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_cloud_workload_security_agent_rules";
+        let local_operation_id = "v2.list_cloud_workload_security_agent_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/cloud_workload_security/agent_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2041,13 +2041,13 @@ impl CSMThreatsAPI {
         datadog::Error<UpdateCSMThreatsAgentPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_csm_threats_agent_policy";
+        let local_operation_id = "v2.update_csm_threats_agent_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/policy/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -2211,7 +2211,7 @@ impl CSMThreatsAPI {
         datadog::Error<UpdateCSMThreatsAgentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_csm_threats_agent_rule";
+        let local_operation_id = "v2.update_csm_threats_agent_rule";
 
         // unbox and build optional parameters
         let policy_id = params.policy_id;
@@ -2220,7 +2220,7 @@ impl CSMThreatsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/cws/agent_rules/{agent_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_rule_id = datadog::urlencode(agent_rule_id)
         );
         let mut local_req_builder =
@@ -2387,13 +2387,13 @@ impl CSMThreatsAPI {
         datadog::Error<UpdateCloudWorkloadSecurityAgentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_cloud_workload_security_agent_rule";
+        let local_operation_id = "v2.update_cloud_workload_security_agent_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/cloud_workload_security/agent_rules/{agent_rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_rule_id = datadog::urlencode(agent_rule_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_customer_org.rs
+++ b/src/datadogV2/api/api_customer_org.rs
@@ -134,9 +134,9 @@ impl CustomerOrgAPI {
         datadog::Error<DisableCustomerOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.disable_customer_org";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.disable_customer_org";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.disable_customer_org' is not enabled".to_string(),
@@ -148,7 +148,7 @@ impl CustomerOrgAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org/disable",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_dashboard_lists.rs
+++ b/src/datadogV2/api/api_dashboard_lists.rs
@@ -154,13 +154,13 @@ impl DashboardListsAPI {
         datadog::Error<CreateDashboardListItemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_dashboard_list_items";
+        let local_operation_id = "v2.create_dashboard_list_items";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/lists/manual/{dashboard_list_id}/dashboards",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_list_id = dashboard_list_id
         );
         let mut local_req_builder =
@@ -315,13 +315,13 @@ impl DashboardListsAPI {
         datadog::Error<DeleteDashboardListItemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_dashboard_list_items";
+        let local_operation_id = "v2.delete_dashboard_list_items";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/lists/manual/{dashboard_list_id}/dashboards",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_list_id = dashboard_list_id
         );
         let mut local_req_builder =
@@ -474,13 +474,13 @@ impl DashboardListsAPI {
         datadog::Error<GetDashboardListItemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_dashboard_list_items";
+        let local_operation_id = "v2.get_dashboard_list_items";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/lists/manual/{dashboard_list_id}/dashboards",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_list_id = dashboard_list_id
         );
         let mut local_req_builder =
@@ -588,13 +588,13 @@ impl DashboardListsAPI {
         datadog::Error<UpdateDashboardListItemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_dashboard_list_items";
+        let local_operation_id = "v2.update_dashboard_list_items";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/lists/manual/{dashboard_list_id}/dashboards",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_list_id = dashboard_list_id
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_dashboard_secure_embed.rs
+++ b/src/datadogV2/api/api_dashboard_secure_embed.rs
@@ -164,9 +164,9 @@ impl DashboardSecureEmbedAPI {
         datadog::Error<CreateDashboardSecureEmbedError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_dashboard_secure_embed";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_dashboard_secure_embed";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_dashboard_secure_embed' is not enabled".to_string(),
@@ -178,7 +178,7 @@ impl DashboardSecureEmbedAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/{dashboard_id}/shared/secure-embed",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id)
         );
         let mut local_req_builder =
@@ -319,9 +319,9 @@ impl DashboardSecureEmbedAPI {
         token: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDashboardSecureEmbedError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_dashboard_secure_embed";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_dashboard_secure_embed";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_dashboard_secure_embed' is not enabled".to_string(),
@@ -333,7 +333,7 @@ impl DashboardSecureEmbedAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/{dashboard_id}/shared/secure-embed/{token}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id),
             token = datadog::urlencode(token)
         );
@@ -435,9 +435,9 @@ impl DashboardSecureEmbedAPI {
         datadog::Error<GetDashboardSecureEmbedError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_dashboard_secure_embed";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_dashboard_secure_embed";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_dashboard_secure_embed' is not enabled".to_string(),
@@ -449,7 +449,7 @@ impl DashboardSecureEmbedAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/{dashboard_id}/shared/secure-embed/{token}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id),
             token = datadog::urlencode(token)
         );
@@ -560,9 +560,9 @@ impl DashboardSecureEmbedAPI {
         datadog::Error<UpdateDashboardSecureEmbedError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_dashboard_secure_embed";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_dashboard_secure_embed";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_dashboard_secure_embed' is not enabled".to_string(),
@@ -574,7 +574,7 @@ impl DashboardSecureEmbedAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/{dashboard_id}/shared/secure-embed/{token}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id),
             token = datadog::urlencode(token)
         );

--- a/src/datadogV2/api/api_dashboard_sharing.rs
+++ b/src/datadogV2/api/api_dashboard_sharing.rs
@@ -123,9 +123,9 @@ impl DashboardSharingAPI {
         datadog::Error<ListSharedDashboardsByDashboardIdError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_shared_dashboards_by_dashboard_id";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_shared_dashboards_by_dashboard_id";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_shared_dashboards_by_dashboard_id' is not enabled"
@@ -138,7 +138,7 @@ impl DashboardSharingAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/dashboard/{dashboard_id}/shared",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_dashboards.rs
+++ b/src/datadogV2/api/api_dashboards.rs
@@ -169,9 +169,9 @@ impl DashboardsAPI {
         datadog::Error<GetDashboardUsageError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_dashboard_usage";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_dashboard_usage";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_dashboard_usage' is not enabled".to_string(),
@@ -183,7 +183,7 @@ impl DashboardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/dashboards/{dashboard_id}/usage",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dashboard_id = datadog::urlencode(dashboard_id)
         );
         let mut local_req_builder =
@@ -322,9 +322,9 @@ impl DashboardsAPI {
         datadog::Error<ListDashboardsUsageError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_dashboards_usage";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_dashboards_usage";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_dashboards_usage' is not enabled".to_string(),
@@ -342,7 +342,7 @@ impl DashboardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/dashboards/usage",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_data_deletion.rs
+++ b/src/datadogV2/api/api_data_deletion.rs
@@ -184,9 +184,9 @@ impl DataDeletionAPI {
         datadog::Error<CancelDataDeletionRequestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.cancel_data_deletion_request";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.cancel_data_deletion_request";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.cancel_data_deletion_request' is not enabled".to_string(),
@@ -198,7 +198,7 @@ impl DataDeletionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deletion/requests/{id}/cancel",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -306,9 +306,9 @@ impl DataDeletionAPI {
         datadog::Error<CreateDataDeletionRequestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_data_deletion_request";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_data_deletion_request";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_data_deletion_request' is not enabled".to_string(),
@@ -320,7 +320,7 @@ impl DataDeletionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deletion/data/{product}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             product = datadog::urlencode(product)
         );
         let mut local_req_builder =
@@ -470,9 +470,9 @@ impl DataDeletionAPI {
         datadog::Error<GetDataDeletionRequestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_data_deletion_requests";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_data_deletion_requests";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_data_deletion_requests' is not enabled".to_string(),
@@ -491,7 +491,7 @@ impl DataDeletionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deletion/requests",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_data_observability.rs
+++ b/src/datadogV2/api/api_data_observability.rs
@@ -134,9 +134,9 @@ impl DataObservabilityAPI {
         datadog::Error<GetDataObservabilityMonitorRunStatusError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_data_observability_monitor_run_status";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_data_observability_monitor_run_status";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_data_observability_monitor_run_status' is not enabled"
@@ -149,7 +149,7 @@ impl DataObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/data-observability/monitors/runs/{run_id}/status",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             run_id = datadog::urlencode(run_id)
         );
         let mut local_req_builder =
@@ -256,9 +256,9 @@ impl DataObservabilityAPI {
         datadog::Error<RunDataObservabilityMonitorError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.run_data_observability_monitor";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.run_data_observability_monitor";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.run_data_observability_monitor' is not enabled".to_string(),
@@ -270,7 +270,7 @@ impl DataObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/data-observability/monitors/{monitor_id}/run",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             monitor_id = monitor_id
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_datasets.rs
+++ b/src/datadogV2/api/api_datasets.rs
@@ -156,9 +156,9 @@ impl DatasetsAPI {
         datadog::Error<CreateDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_dataset' is not enabled".to_string(),
@@ -170,7 +170,7 @@ impl DatasetsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/datasets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -305,9 +305,9 @@ impl DatasetsAPI {
         dataset_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDatasetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_dataset' is not enabled".to_string(),
@@ -319,7 +319,7 @@ impl DatasetsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/datasets/{dataset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =
@@ -411,9 +411,9 @@ impl DatasetsAPI {
         datadog::Error<GetAllDatasetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_all_datasets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_all_datasets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_all_datasets' is not enabled".to_string(),
@@ -425,7 +425,7 @@ impl DatasetsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/datasets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -525,9 +525,9 @@ impl DatasetsAPI {
         datadog::Error<GetDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_dataset' is not enabled".to_string(),
@@ -539,7 +539,7 @@ impl DatasetsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/datasets/{dataset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =
@@ -641,9 +641,9 @@ impl DatasetsAPI {
         datadog::Error<UpdateDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_dataset' is not enabled".to_string(),
@@ -655,7 +655,7 @@ impl DatasetsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/datasets/{dataset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_ddsql.rs
+++ b/src/datadogV2/api/api_ddsql.rs
@@ -141,9 +141,9 @@ impl DDSQLAPI {
         datadog::Error<ExecuteDdsqlTabularQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.execute_ddsql_tabular_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.execute_ddsql_tabular_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.execute_ddsql_tabular_query' is not enabled".to_string(),
@@ -155,7 +155,7 @@ impl DDSQLAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ddsql/query/tabular",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -310,9 +310,9 @@ impl DDSQLAPI {
         datadog::Error<FetchDdsqlTabularQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.fetch_ddsql_tabular_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.fetch_ddsql_tabular_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.fetch_ddsql_tabular_query' is not enabled".to_string(),
@@ -324,7 +324,7 @@ impl DDSQLAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ddsql/query/tabular/fetch",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_deployment_gates.rs
+++ b/src/datadogV2/api/api_deployment_gates.rs
@@ -267,9 +267,9 @@ impl DeploymentGatesAPI {
         datadog::Error<CreateDeploymentGateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_deployment_gate";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_deployment_gate";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_deployment_gate' is not enabled".to_string(),
@@ -281,7 +281,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -435,9 +435,9 @@ impl DeploymentGatesAPI {
         datadog::Error<CreateDeploymentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_deployment_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_deployment_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_deployment_rule' is not enabled".to_string(),
@@ -449,7 +449,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{gate_id}/rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             gate_id = datadog::urlencode(gate_id)
         );
         let mut local_req_builder =
@@ -585,9 +585,9 @@ impl DeploymentGatesAPI {
         id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDeploymentGateError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_deployment_gate";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_deployment_gate";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_deployment_gate' is not enabled".to_string(),
@@ -599,7 +599,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -686,9 +686,9 @@ impl DeploymentGatesAPI {
         id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDeploymentRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_deployment_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_deployment_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_deployment_rule' is not enabled".to_string(),
@@ -700,7 +700,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{gate_id}/rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             gate_id = datadog::urlencode(gate_id),
             id = datadog::urlencode(id)
         );
@@ -797,9 +797,9 @@ impl DeploymentGatesAPI {
         datadog::Error<GetDeploymentGateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_deployment_gate";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_deployment_gate";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_deployment_gate' is not enabled".to_string(),
@@ -811,7 +811,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -914,9 +914,9 @@ impl DeploymentGatesAPI {
         datadog::Error<GetDeploymentGateRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_deployment_gate_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_deployment_gate_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_deployment_gate_rules' is not enabled".to_string(),
@@ -928,7 +928,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{gate_id}/rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             gate_id = datadog::urlencode(gate_id)
         );
         let mut local_req_builder =
@@ -1042,9 +1042,9 @@ impl DeploymentGatesAPI {
         datadog::Error<GetDeploymentGatesEvaluationResultError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_deployment_gates_evaluation_result";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_deployment_gates_evaluation_result";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_deployment_gates_evaluation_result' is not enabled"
@@ -1057,7 +1057,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployments/gates/evaluation/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -1163,9 +1163,9 @@ impl DeploymentGatesAPI {
         datadog::Error<GetDeploymentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_deployment_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_deployment_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_deployment_rule' is not enabled".to_string(),
@@ -1177,7 +1177,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{gate_id}/rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             gate_id = datadog::urlencode(gate_id),
             id = datadog::urlencode(id)
         );
@@ -1283,9 +1283,9 @@ impl DeploymentGatesAPI {
         datadog::Error<ListDeploymentGatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_deployment_gates";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_deployment_gates";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_deployment_gates' is not enabled".to_string(),
@@ -1301,7 +1301,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1427,9 +1427,9 @@ impl DeploymentGatesAPI {
         datadog::Error<TriggerDeploymentGatesEvaluationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.trigger_deployment_gates_evaluation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.trigger_deployment_gates_evaluation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.trigger_deployment_gates_evaluation' is not enabled"
@@ -1442,7 +1442,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployments/gates/evaluation",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1593,9 +1593,9 @@ impl DeploymentGatesAPI {
         datadog::Error<UpdateDeploymentGateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_deployment_gate";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_deployment_gate";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_deployment_gate' is not enabled".to_string(),
@@ -1607,7 +1607,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1764,9 +1764,9 @@ impl DeploymentGatesAPI {
         datadog::Error<UpdateDeploymentRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_deployment_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_deployment_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_deployment_rule' is not enabled".to_string(),
@@ -1778,7 +1778,7 @@ impl DeploymentGatesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/deployment_gates/{gate_id}/rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             gate_id = datadog::urlencode(gate_id),
             id = datadog::urlencode(id)
         );

--- a/src/datadogV2/api/api_domain_allowlist.rs
+++ b/src/datadogV2/api/api_domain_allowlist.rs
@@ -131,13 +131,13 @@ impl DomainAllowlistAPI {
         datadog::Error<GetDomainAllowlistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_domain_allowlist";
+        let local_operation_id = "v2.get_domain_allowlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/domain_allowlist",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -239,13 +239,13 @@ impl DomainAllowlistAPI {
         datadog::Error<PatchDomainAllowlistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.patch_domain_allowlist";
+        let local_operation_id = "v2.patch_domain_allowlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/domain_allowlist",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());

--- a/src/datadogV2/api/api_dora_metrics.rs
+++ b/src/datadogV2/api/api_dora_metrics.rs
@@ -219,13 +219,13 @@ impl DORAMetricsAPI {
         datadog::Error<CreateDORADeploymentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_dora_deployment";
+        let local_operation_id = "v2.create_dora_deployment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/deployment",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -369,13 +369,13 @@ impl DORAMetricsAPI {
         datadog::Error<CreateDORAFailureError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_dora_failure";
+        let local_operation_id = "v2.create_dora_failure";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/failure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -521,13 +521,13 @@ impl DORAMetricsAPI {
         datadog::Error<CreateDORAIncidentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_dora_incident";
+        let local_operation_id = "v2.create_dora_incident";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/incident",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -658,13 +658,13 @@ impl DORAMetricsAPI {
         deployment_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDORADeploymentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_dora_deployment";
+        let local_operation_id = "v2.delete_dora_deployment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/deployment/{deployment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             deployment_id = datadog::urlencode(deployment_id)
         );
         let mut local_req_builder =
@@ -746,13 +746,13 @@ impl DORAMetricsAPI {
         failure_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDORAFailureError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_dora_failure";
+        let local_operation_id = "v2.delete_dora_failure";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/failure/{failure_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             failure_id = datadog::urlencode(failure_id)
         );
         let mut local_req_builder =
@@ -848,13 +848,13 @@ impl DORAMetricsAPI {
         datadog::Error<GetDORADeploymentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_dora_deployment";
+        let local_operation_id = "v2.get_dora_deployment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/deployments/{deployment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             deployment_id = datadog::urlencode(deployment_id)
         );
         let mut local_req_builder =
@@ -957,13 +957,13 @@ impl DORAMetricsAPI {
         datadog::Error<GetDORAFailureError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_dora_failure";
+        let local_operation_id = "v2.get_dora_failure";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/failures/{failure_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             failure_id = datadog::urlencode(failure_id)
         );
         let mut local_req_builder =
@@ -1066,13 +1066,13 @@ impl DORAMetricsAPI {
         datadog::Error<ListDORADeploymentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_dora_deployments";
+        let local_operation_id = "v2.list_dora_deployments";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/deployments",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1221,13 +1221,13 @@ impl DORAMetricsAPI {
         datadog::Error<ListDORAFailuresError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_dora_failures";
+        let local_operation_id = "v2.list_dora_failures";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/failures",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1367,13 +1367,13 @@ impl DORAMetricsAPI {
         body: crate::datadogV2::model::DORADeploymentPatchRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<PatchDORADeploymentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.patch_dora_deployment";
+        let local_operation_id = "v2.patch_dora_deployment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/dora/deployments/{deployment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             deployment_id = datadog::urlencode(deployment_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_downtimes.rs
+++ b/src/datadogV2/api/api_downtimes.rs
@@ -240,13 +240,13 @@ impl DowntimesAPI {
         downtime_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CancelDowntimeError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.cancel_downtime";
+        let local_operation_id = "v2.cancel_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/downtime/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id)
         );
         let mut local_req_builder =
@@ -340,13 +340,13 @@ impl DowntimesAPI {
         datadog::Error<CreateDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_downtime";
+        let local_operation_id = "v2.create_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/downtime",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -493,7 +493,7 @@ impl DowntimesAPI {
         datadog::Error<GetDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_downtime";
+        let local_operation_id = "v2.get_downtime";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -502,7 +502,7 @@ impl DowntimesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/downtime/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id)
         );
         let mut local_req_builder =
@@ -643,7 +643,7 @@ impl DowntimesAPI {
         datadog::Error<ListDowntimesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_downtimes";
+        let local_operation_id = "v2.list_downtimes";
 
         // unbox and build optional parameters
         let current_only = params.current_only;
@@ -655,7 +655,7 @@ impl DowntimesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/downtime",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -817,7 +817,7 @@ impl DowntimesAPI {
         datadog::Error<ListMonitorDowntimesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_monitor_downtimes";
+        let local_operation_id = "v2.list_monitor_downtimes";
 
         // unbox and build optional parameters
         let page_offset = params.page_offset;
@@ -827,7 +827,7 @@ impl DowntimesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/{monitor_id}/downtime_matches",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             monitor_id = monitor_id
         );
         let mut local_req_builder =
@@ -939,13 +939,13 @@ impl DowntimesAPI {
         datadog::Error<UpdateDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_downtime";
+        let local_operation_id = "v2.update_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/downtime/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_entity_integration_configs.rs
+++ b/src/datadogV2/api/api_entity_integration_configs.rs
@@ -133,9 +133,9 @@ impl EntityIntegrationConfigsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteEntityIntegrationConfigError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_entity_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_entity_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_entity_integration_config' is not enabled".to_string(),
@@ -147,7 +147,7 @@ impl EntityIntegrationConfigsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/idp/entity_integrations/{integration_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_id = datadog::urlencode(integration_id)
         );
         let mut local_req_builder =
@@ -246,9 +246,9 @@ impl EntityIntegrationConfigsAPI {
         datadog::Error<GetEntityIntegrationConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_entity_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_entity_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_entity_integration_config' is not enabled".to_string(),
@@ -260,7 +260,7 @@ impl EntityIntegrationConfigsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/idp/entity_integrations/{integration_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_id = datadog::urlencode(integration_id)
         );
         let mut local_req_builder =
@@ -376,9 +376,9 @@ impl EntityIntegrationConfigsAPI {
         datadog::Error<UpdateEntityIntegrationConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_entity_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_entity_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_entity_integration_config' is not enabled".to_string(),
@@ -390,7 +390,7 @@ impl EntityIntegrationConfigsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/idp/entity_integrations/{integration_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_id = datadog::urlencode(integration_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_entity_risk_scores.rs
+++ b/src/datadogV2/api/api_entity_risk_scores.rs
@@ -198,9 +198,9 @@ impl EntityRiskScoresAPI {
         datadog::Error<GetEntityRiskScoreError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_entity_risk_score";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_entity_risk_score";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_entity_risk_score' is not enabled".to_string(),
@@ -212,7 +212,7 @@ impl EntityRiskScoresAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security-entities/risk-scores/{entity_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             entity_id = datadog::urlencode(entity_id)
         );
         let mut local_req_builder =
@@ -315,9 +315,9 @@ impl EntityRiskScoresAPI {
         datadog::Error<ListEntityRiskScoresError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_entity_risk_scores";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_entity_risk_scores";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_entity_risk_scores' is not enabled".to_string(),
@@ -339,7 +339,7 @@ impl EntityRiskScoresAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security-entities/risk-scores",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_error_tracking.rs
+++ b/src/datadogV2/api/api_error_tracking.rs
@@ -179,13 +179,13 @@ impl ErrorTrackingAPI {
         issue_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIssueAssigneeError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_issue_assignee";
+        let local_operation_id = "v2.delete_issue_assignee";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/error-tracking/issues/{issue_id}/assignee",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             issue_id = datadog::urlencode(issue_id)
         );
         let mut local_req_builder =
@@ -280,7 +280,7 @@ impl ErrorTrackingAPI {
         datadog::Error<GetIssueError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_issue";
+        let local_operation_id = "v2.get_issue";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -289,7 +289,7 @@ impl ErrorTrackingAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/error-tracking/issues/{issue_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             issue_id = datadog::urlencode(issue_id)
         );
         let mut local_req_builder =
@@ -401,7 +401,7 @@ impl ErrorTrackingAPI {
         datadog::Error<SearchIssuesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_issues";
+        let local_operation_id = "v2.search_issues";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -410,7 +410,7 @@ impl ErrorTrackingAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/error-tracking/issues/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -573,13 +573,13 @@ impl ErrorTrackingAPI {
         datadog::Error<UpdateIssueAssigneeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_issue_assignee";
+        let local_operation_id = "v2.update_issue_assignee";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/error-tracking/issues/{issue_id}/assignee",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             issue_id = datadog::urlencode(issue_id)
         );
         let mut local_req_builder =
@@ -726,13 +726,13 @@ impl ErrorTrackingAPI {
         datadog::Error<UpdateIssueStateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_issue_state";
+        let local_operation_id = "v2.update_issue_state";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/error-tracking/issues/{issue_id}/state",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             issue_id = datadog::urlencode(issue_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_events.rs
+++ b/src/datadogV2/api/api_events.rs
@@ -231,13 +231,13 @@ impl EventsAPI {
         datadog::Error<CreateEventError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_event";
+        let local_operation_id = "v2.create_event";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -382,13 +382,13 @@ impl EventsAPI {
         datadog::Error<GetEventError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_event";
+        let local_operation_id = "v2.get_event";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/events/{event_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             event_id = datadog::urlencode(event_id)
         );
         let mut local_req_builder =
@@ -525,7 +525,7 @@ impl EventsAPI {
         datadog::Error<ListEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_events";
+        let local_operation_id = "v2.list_events";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -539,7 +539,7 @@ impl EventsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -709,7 +709,7 @@ impl EventsAPI {
         datadog::Error<SearchEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_events";
+        let local_operation_id = "v2.search_events";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -718,7 +718,7 @@ impl EventsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_fastly_integration.rs
+++ b/src/datadogV2/api/api_fastly_integration.rs
@@ -195,13 +195,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<CreateFastlyAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_fastly_account";
+        let local_operation_id = "v2.create_fastly_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -355,13 +355,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<CreateFastlyServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_fastly_service";
+        let local_operation_id = "v2.create_fastly_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}/services",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -497,13 +497,13 @@ impl FastlyIntegrationAPI {
         account_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteFastlyAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_fastly_account";
+        let local_operation_id = "v2.delete_fastly_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -590,13 +590,13 @@ impl FastlyIntegrationAPI {
         service_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteFastlyServiceError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_fastly_service";
+        let local_operation_id = "v2.delete_fastly_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}/services/{service_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id),
             service_id = datadog::urlencode(service_id)
         );
@@ -691,13 +691,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<GetFastlyAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_fastly_account";
+        let local_operation_id = "v2.get_fastly_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -803,13 +803,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<GetFastlyServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_fastly_service";
+        let local_operation_id = "v2.get_fastly_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}/services/{service_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id),
             service_id = datadog::urlencode(service_id)
         );
@@ -911,13 +911,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<ListFastlyAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fastly_accounts";
+        let local_operation_id = "v2.list_fastly_accounts";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1019,13 +1019,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<ListFastlyServicesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fastly_services";
+        let local_operation_id = "v2.list_fastly_services";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}/services",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -1133,13 +1133,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<UpdateFastlyAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_fastly_account";
+        let local_operation_id = "v2.update_fastly_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -1296,13 +1296,13 @@ impl FastlyIntegrationAPI {
         datadog::Error<UpdateFastlyServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_fastly_service";
+        let local_operation_id = "v2.update_fastly_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/fastly/accounts/{account_id}/services/{service_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id),
             service_id = datadog::urlencode(service_id)
         );

--- a/src/datadogV2/api/api_feature_flags.rs
+++ b/src/datadogV2/api/api_feature_flags.rs
@@ -375,13 +375,13 @@ impl FeatureFlagsAPI {
         datadog::Error<ArchiveFeatureFlagError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.archive_feature_flag";
+        let local_operation_id = "v2.archive_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/archive",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string())
         );
         let mut local_req_builder =
@@ -495,13 +495,13 @@ impl FeatureFlagsAPI {
         datadog::Error<CreateAllocationsForFeatureFlagInEnvironmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_allocations_for_feature_flag_in_environment";
+        let local_operation_id = "v2.create_allocations_for_feature_flag_in_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/environments/{environment_id}/allocations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string()),
             environment_id = datadog::urlencode(environment_id.to_string())
         );
@@ -650,13 +650,13 @@ impl FeatureFlagsAPI {
         datadog::Error<CreateFeatureFlagError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_feature_flag";
+        let local_operation_id = "v2.create_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -808,13 +808,13 @@ impl FeatureFlagsAPI {
         datadog::Error<CreateFeatureFlagsEnvironmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_feature_flags_environment";
+        let local_operation_id = "v2.create_feature_flags_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/environments",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -978,13 +978,13 @@ impl FeatureFlagsAPI {
         datadog::Error<CreateVariantForFeatureFlagError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_variant_for_feature_flag";
+        let local_operation_id = "v2.create_variant_for_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/variants",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string())
         );
         let mut local_req_builder =
@@ -1122,13 +1122,13 @@ impl FeatureFlagsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteFeatureFlagsEnvironmentError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_feature_flags_environment";
+        let local_operation_id = "v2.delete_feature_flags_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/environments/{environment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             environment_id = datadog::urlencode(environment_id.to_string())
         );
         let mut local_req_builder =
@@ -1220,13 +1220,13 @@ impl FeatureFlagsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteVariantFromFeatureFlagError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_variant_from_feature_flag";
+        let local_operation_id = "v2.delete_variant_from_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/variants/{variant_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string()),
             variant_id = datadog::urlencode(variant_id.to_string())
         );
@@ -1315,13 +1315,13 @@ impl FeatureFlagsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DisableFeatureFlagEnvironmentError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.disable_feature_flag_environment";
+        let local_operation_id = "v2.disable_feature_flag_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/environments/{environment_id}/disable",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string()),
             environment_id = datadog::urlencode(environment_id.to_string())
         );
@@ -1410,13 +1410,13 @@ impl FeatureFlagsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<EnableFeatureFlagEnvironmentError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.enable_feature_flag_environment";
+        let local_operation_id = "v2.enable_feature_flag_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/environments/{environment_id}/enable",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string()),
             environment_id = datadog::urlencode(environment_id.to_string())
         );
@@ -1513,13 +1513,13 @@ impl FeatureFlagsAPI {
         datadog::Error<GetFeatureFlagError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_feature_flag";
+        let local_operation_id = "v2.get_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string())
         );
         let mut local_req_builder =
@@ -1625,13 +1625,13 @@ impl FeatureFlagsAPI {
         datadog::Error<GetFeatureFlagsEnvironmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_feature_flags_environment";
+        let local_operation_id = "v2.get_feature_flags_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/environments/{environment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             environment_id = datadog::urlencode(environment_id.to_string())
         );
         let mut local_req_builder =
@@ -1736,7 +1736,7 @@ impl FeatureFlagsAPI {
         datadog::Error<ListFeatureFlagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_feature_flags";
+        let local_operation_id = "v2.list_feature_flags";
 
         // unbox and build optional parameters
         let key = params.key;
@@ -1748,7 +1748,7 @@ impl FeatureFlagsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1871,7 +1871,7 @@ impl FeatureFlagsAPI {
         datadog::Error<ListFeatureFlagsEnvironmentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_feature_flags_environments";
+        let local_operation_id = "v2.list_feature_flags_environments";
 
         // unbox and build optional parameters
         let name = params.name;
@@ -1884,7 +1884,7 @@ impl FeatureFlagsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/environments",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2009,13 +2009,13 @@ impl FeatureFlagsAPI {
         datadog::Error<PauseExposureScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.pause_exposure_schedule";
+        let local_operation_id = "v2.pause_exposure_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/exposure-schedules/{exposure_schedule_id}/pause",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             exposure_schedule_id = datadog::urlencode(exposure_schedule_id.to_string())
         );
         let mut local_req_builder =
@@ -2121,13 +2121,13 @@ impl FeatureFlagsAPI {
         datadog::Error<ResumeExposureScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.resume_exposure_schedule";
+        let local_operation_id = "v2.resume_exposure_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/exposure-schedules/{exposure_schedule_id}/resume",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             exposure_schedule_id = datadog::urlencode(exposure_schedule_id.to_string())
         );
         let mut local_req_builder =
@@ -2233,13 +2233,13 @@ impl FeatureFlagsAPI {
         datadog::Error<StartExposureScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.start_exposure_schedule";
+        let local_operation_id = "v2.start_exposure_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/exposure-schedules/{exposure_schedule_id}/start",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             exposure_schedule_id = datadog::urlencode(exposure_schedule_id.to_string())
         );
         let mut local_req_builder =
@@ -2345,13 +2345,13 @@ impl FeatureFlagsAPI {
         datadog::Error<StopExposureScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.stop_exposure_schedule";
+        let local_operation_id = "v2.stop_exposure_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/exposure-schedules/{exposure_schedule_id}/stop",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             exposure_schedule_id = datadog::urlencode(exposure_schedule_id.to_string())
         );
         let mut local_req_builder =
@@ -2459,13 +2459,13 @@ impl FeatureFlagsAPI {
         datadog::Error<UnarchiveFeatureFlagError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.unarchive_feature_flag";
+        let local_operation_id = "v2.unarchive_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/unarchive",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string())
         );
         let mut local_req_builder =
@@ -2581,13 +2581,13 @@ impl FeatureFlagsAPI {
         datadog::Error<UpdateAllocationsForFeatureFlagInEnvironmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_allocations_for_feature_flag_in_environment";
+        let local_operation_id = "v2.update_allocations_for_feature_flag_in_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/environments/{environment_id}/allocations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string()),
             environment_id = datadog::urlencode(environment_id.to_string())
         );
@@ -2743,13 +2743,13 @@ impl FeatureFlagsAPI {
         datadog::Error<UpdateFeatureFlagError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_feature_flag";
+        let local_operation_id = "v2.update_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string())
         );
         let mut local_req_builder =
@@ -2906,13 +2906,13 @@ impl FeatureFlagsAPI {
         datadog::Error<UpdateFeatureFlagsEnvironmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_feature_flags_environment";
+        let local_operation_id = "v2.update_feature_flags_environment";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/environments/{environment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             environment_id = datadog::urlencode(environment_id.to_string())
         );
         let mut local_req_builder =
@@ -3071,13 +3071,13 @@ impl FeatureFlagsAPI {
         datadog::Error<UpdateVariantForFeatureFlagError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_variant_for_feature_flag";
+        let local_operation_id = "v2.update_variant_for_feature_flag";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/feature-flags/{feature_flag_id}/variants/{variant_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             feature_flag_id = datadog::urlencode(feature_flag_id.to_string()),
             variant_id = datadog::urlencode(variant_id.to_string())
         );

--- a/src/datadogV2/api/api_fleet_automation.rs
+++ b/src/datadogV2/api/api_fleet_automation.rs
@@ -436,9 +436,9 @@ impl FleetAutomationAPI {
         deployment_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CancelFleetDeploymentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.cancel_fleet_deployment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.cancel_fleet_deployment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.cancel_fleet_deployment' is not enabled".to_string(),
@@ -450,7 +450,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/deployments/{deployment_id}/cancel",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             deployment_id = datadog::urlencode(deployment_id)
         );
         let mut local_req_builder =
@@ -569,9 +569,9 @@ impl FleetAutomationAPI {
         datadog::Error<CreateFleetDeploymentConfigureError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_fleet_deployment_configure";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_fleet_deployment_configure";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_fleet_deployment_configure' is not enabled".to_string(),
@@ -583,7 +583,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/deployments/configure",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -753,9 +753,9 @@ impl FleetAutomationAPI {
         datadog::Error<CreateFleetDeploymentUpgradeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_fleet_deployment_upgrade";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_fleet_deployment_upgrade";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_fleet_deployment_upgrade' is not enabled".to_string(),
@@ -767,7 +767,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/deployments/upgrade",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -934,9 +934,9 @@ impl FleetAutomationAPI {
         datadog::Error<CreateFleetScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_fleet_schedule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_fleet_schedule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_fleet_schedule' is not enabled".to_string(),
@@ -948,7 +948,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/schedules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1099,9 +1099,9 @@ impl FleetAutomationAPI {
         id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteFleetScheduleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_fleet_schedule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_fleet_schedule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_fleet_schedule' is not enabled".to_string(),
@@ -1113,7 +1113,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/schedules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1219,9 +1219,9 @@ impl FleetAutomationAPI {
         datadog::Error<GetFleetAgentInfoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_fleet_agent_info";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_fleet_agent_info";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_fleet_agent_info' is not enabled".to_string(),
@@ -1233,7 +1233,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/agents/{agent_key}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_key = datadog::urlencode(agent_key)
         );
         let mut local_req_builder =
@@ -1379,9 +1379,9 @@ impl FleetAutomationAPI {
         datadog::Error<GetFleetDeploymentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_fleet_deployment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_fleet_deployment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_fleet_deployment' is not enabled".to_string(),
@@ -1397,7 +1397,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/deployments/{deployment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             deployment_id = datadog::urlencode(deployment_id)
         );
         let mut local_req_builder =
@@ -1521,9 +1521,9 @@ impl FleetAutomationAPI {
         datadog::Error<GetFleetScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_fleet_schedule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_fleet_schedule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_fleet_schedule' is not enabled".to_string(),
@@ -1535,7 +1535,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/schedules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1649,9 +1649,9 @@ impl FleetAutomationAPI {
         datadog::Error<ListFleetAgentTracersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fleet_agent_tracers";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_fleet_agent_tracers";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_fleet_agent_tracers' is not enabled".to_string(),
@@ -1669,7 +1669,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/agents/{agent_key}/tracers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             agent_key = datadog::urlencode(agent_key)
         );
         let mut local_req_builder =
@@ -1795,9 +1795,9 @@ impl FleetAutomationAPI {
         datadog::Error<ListFleetAgentVersionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fleet_agent_versions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_fleet_agent_versions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_fleet_agent_versions' is not enabled".to_string(),
@@ -1809,7 +1809,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/agent_versions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1913,9 +1913,9 @@ impl FleetAutomationAPI {
         datadog::Error<ListFleetAgentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fleet_agents";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_fleet_agents";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_fleet_agents' is not enabled".to_string(),
@@ -1935,7 +1935,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/agents",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2064,9 +2064,9 @@ impl FleetAutomationAPI {
         datadog::Error<ListFleetDeploymentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fleet_deployments";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_fleet_deployments";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_fleet_deployments' is not enabled".to_string(),
@@ -2082,7 +2082,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/deployments",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2199,9 +2199,9 @@ impl FleetAutomationAPI {
         datadog::Error<ListFleetSchedulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fleet_schedules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_fleet_schedules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_fleet_schedules' is not enabled".to_string(),
@@ -2213,7 +2213,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/schedules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2323,9 +2323,9 @@ impl FleetAutomationAPI {
         datadog::Error<ListFleetTracersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_fleet_tracers";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_fleet_tracers";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_fleet_tracers' is not enabled".to_string(),
@@ -2344,7 +2344,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/tracers",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2497,9 +2497,9 @@ impl FleetAutomationAPI {
         datadog::Error<TriggerFleetScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.trigger_fleet_schedule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.trigger_fleet_schedule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.trigger_fleet_schedule' is not enabled".to_string(),
@@ -2511,7 +2511,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/schedules/{id}/trigger",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -2636,9 +2636,9 @@ impl FleetAutomationAPI {
         datadog::Error<UpdateFleetScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_fleet_schedule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_fleet_schedule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_fleet_schedule' is not enabled".to_string(),
@@ -2650,7 +2650,7 @@ impl FleetAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/fleet/schedules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_forms.rs
+++ b/src/datadogV2/api/api_forms.rs
@@ -222,9 +222,9 @@ impl FormsAPI {
         datadog::Error<CloneFormError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.clone_form";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.clone_form";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.clone_form' is not enabled".to_string(),
@@ -236,7 +236,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/{form_id}/clone",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             form_id = datadog::urlencode(form_id.to_string())
         );
         let mut local_req_builder =
@@ -381,9 +381,9 @@ impl FormsAPI {
         datadog::Error<CreateAndPublishFormError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_and_publish_form";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_and_publish_form";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_and_publish_form' is not enabled".to_string(),
@@ -395,7 +395,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/create_and_publish",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -539,9 +539,9 @@ impl FormsAPI {
         datadog::Error<CreateFormError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_form";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_form";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_form' is not enabled".to_string(),
@@ -553,7 +553,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -696,9 +696,9 @@ impl FormsAPI {
         datadog::Error<DeleteFormError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_form";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_form";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_form' is not enabled".to_string(),
@@ -710,7 +710,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/{form_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             form_id = datadog::urlencode(form_id.to_string())
         );
         let mut local_req_builder =
@@ -811,9 +811,9 @@ impl FormsAPI {
         datadog::Error<GetFormError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_form";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_form";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_form' is not enabled".to_string(),
@@ -828,7 +828,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/{form_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             form_id = datadog::urlencode(form_id.to_string())
         );
         let mut local_req_builder =
@@ -928,9 +928,9 @@ impl FormsAPI {
         datadog::Error<ListFormsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_forms";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_forms";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_forms' is not enabled".to_string(),
@@ -942,7 +942,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1041,9 +1041,9 @@ impl FormsAPI {
         datadog::Error<PublishFormError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.publish_form";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.publish_form";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.publish_form' is not enabled".to_string(),
@@ -1055,7 +1055,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/{form_id}/publish",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             form_id = datadog::urlencode(form_id.to_string())
         );
         let mut local_req_builder =
@@ -1203,9 +1203,9 @@ impl FormsAPI {
         datadog::Error<UpdateFormError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_form";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_form";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_form' is not enabled".to_string(),
@@ -1217,7 +1217,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/{form_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             form_id = datadog::urlencode(form_id.to_string())
         );
         let mut local_req_builder =
@@ -1369,9 +1369,9 @@ impl FormsAPI {
         datadog::Error<UpsertAndPublishFormVersionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_and_publish_form_version";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.upsert_and_publish_form_version";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.upsert_and_publish_form_version' is not enabled".to_string(),
@@ -1383,7 +1383,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/{form_id}/versions/upsert_and_publish",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             form_id = datadog::urlencode(form_id.to_string())
         );
         let mut local_req_builder =
@@ -1533,9 +1533,9 @@ impl FormsAPI {
         datadog::Error<UpsertFormVersionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_form_version";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.upsert_form_version";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.upsert_form_version' is not enabled".to_string(),
@@ -1547,7 +1547,7 @@ impl FormsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/forms/{form_id}/versions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             form_id = datadog::urlencode(form_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_gcp_integration.rs
+++ b/src/datadogV2/api/api_gcp_integration.rs
@@ -180,13 +180,13 @@ impl GCPIntegrationAPI {
         datadog::Error<CreateGCPSTSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_gcpsts_account";
+        let local_operation_id = "v2.create_gcpsts_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/gcp/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -321,13 +321,13 @@ impl GCPIntegrationAPI {
         account_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteGCPSTSAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_gcpsts_account";
+        let local_operation_id = "v2.delete_gcpsts_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/gcp/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -421,13 +421,13 @@ impl GCPIntegrationAPI {
         datadog::Error<GetGCPSTSDelegateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_gcpsts_delegate";
+        let local_operation_id = "v2.get_gcpsts_delegate";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/gcp/sts_delegate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -527,13 +527,13 @@ impl GCPIntegrationAPI {
         datadog::Error<ListGCPSTSAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_gcpsts_accounts";
+        let local_operation_id = "v2.list_gcpsts_accounts";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/gcp/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -635,7 +635,7 @@ impl GCPIntegrationAPI {
         datadog::Error<MakeGCPSTSDelegateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.make_gcpsts_delegate";
+        let local_operation_id = "v2.make_gcpsts_delegate";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -644,7 +644,7 @@ impl GCPIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/gcp/sts_delegate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -798,13 +798,13 @@ impl GCPIntegrationAPI {
         datadog::Error<UpdateGCPSTSAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_gcpsts_account";
+        let local_operation_id = "v2.update_gcpsts_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/gcp/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_google_chat_integration.rs
+++ b/src/datadogV2/api/api_google_chat_integration.rs
@@ -249,13 +249,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<CreateGoogleChatTargetAudienceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_google_chat_target_audience";
+        let local_operation_id = "v2.create_google_chat_target_audience";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/target-audiences",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             );
         let mut local_req_builder =
@@ -410,13 +410,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<CreateOrganizationHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_organization_handle";
+        let local_operation_id = "v2.create_organization_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/organization-handles",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             );
         let mut local_req_builder =
@@ -557,13 +557,13 @@ impl GoogleChatIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteGoogleChatDelegatedUserError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_google_chat_delegated_user";
+        let local_operation_id = "v2.delete_google_chat_delegated_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/delegated-user",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             );
         let mut local_req_builder =
@@ -649,13 +649,13 @@ impl GoogleChatIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteGoogleChatOrganizationError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_google_chat_organization";
+        let local_operation_id = "v2.delete_google_chat_organization";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             organization_binding_id = datadog::urlencode(organization_binding_id)
         );
         let mut local_req_builder =
@@ -746,13 +746,13 @@ impl GoogleChatIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteGoogleChatTargetAudienceError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_google_chat_target_audience";
+        let local_operation_id = "v2.delete_google_chat_target_audience";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/target-audiences/{target_audience_id}",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             , target_audience_id=
             datadog::urlencode(target_audience_id)
@@ -841,13 +841,13 @@ impl GoogleChatIntegrationAPI {
         handle_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOrganizationHandleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_organization_handle";
+        let local_operation_id = "v2.delete_organization_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/organization-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             , handle_id=
             datadog::urlencode(handle_id)
@@ -948,13 +948,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<GetGoogleChatDelegatedUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_google_chat_delegated_user";
+        let local_operation_id = "v2.get_google_chat_delegated_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/delegated-user",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             );
         let mut local_req_builder =
@@ -1060,13 +1060,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<GetGoogleChatOrganizationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_google_chat_organization";
+        let local_operation_id = "v2.get_google_chat_organization";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             organization_binding_id = datadog::urlencode(organization_binding_id)
         );
         let mut local_req_builder =
@@ -1177,13 +1177,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<GetGoogleChatTargetAudienceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_google_chat_target_audience";
+        let local_operation_id = "v2.get_google_chat_target_audience";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/target-audiences/{target_audience_id}",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             , target_audience_id=
             datadog::urlencode(target_audience_id)
@@ -1293,13 +1293,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<GetOrganizationHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_organization_handle";
+        let local_operation_id = "v2.get_organization_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/organization-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             , handle_id=
             datadog::urlencode(handle_id)
@@ -1410,13 +1410,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<GetSpaceByDisplayNameError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_space_by_display_name";
+        let local_operation_id = "v2.get_space_by_display_name";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/app/named-spaces/{domain_name}/{space_display_name}",
-            local_configuration.get_operation_host(operation_id), domain_name=
+            local_configuration.get_operation_host(local_operation_id), domain_name=
             datadog::urlencode(domain_name)
             , space_display_name=
             datadog::urlencode(space_display_name)
@@ -1519,13 +1519,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<ListGoogleChatOrganizationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_google_chat_organizations";
+        let local_operation_id = "v2.list_google_chat_organizations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1630,13 +1630,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<ListGoogleChatTargetAudiencesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_google_chat_target_audiences";
+        let local_operation_id = "v2.list_google_chat_target_audiences";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/target-audiences",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             );
         let mut local_req_builder =
@@ -1742,13 +1742,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<ListOrganizationHandlesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_organization_handles";
+        let local_operation_id = "v2.list_organization_handles";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/organization-handles",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             );
         let mut local_req_builder =
@@ -1863,13 +1863,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<UpdateGoogleChatTargetAudienceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_google_chat_target_audience";
+        let local_operation_id = "v2.update_google_chat_target_audience";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/target-audiences/{target_audience_id}",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             , target_audience_id=
             datadog::urlencode(target_audience_id)
@@ -2028,13 +2028,13 @@ impl GoogleChatIntegrationAPI {
         datadog::Error<UpdateOrganizationHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_organization_handle";
+        let local_operation_id = "v2.update_organization_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/google-chat/organizations/{organization_binding_id}/organization-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id), organization_binding_id=
+            local_configuration.get_operation_host(local_operation_id), organization_binding_id=
             datadog::urlencode(organization_binding_id)
             , handle_id=
             datadog::urlencode(handle_id)

--- a/src/datadogV2/api/api_governance_controls.rs
+++ b/src/datadogV2/api/api_governance_controls.rs
@@ -151,9 +151,9 @@ impl GovernanceControlsAPI {
         datadog::Error<GetGovernanceControlError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_governance_control";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_governance_control";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_governance_control' is not enabled".to_string(),
@@ -165,7 +165,7 @@ impl GovernanceControlsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/governance/control/{detection_type}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             detection_type = datadog::urlencode(detection_type)
         );
         let mut local_req_builder =
@@ -270,9 +270,9 @@ impl GovernanceControlsAPI {
         datadog::Error<ListGovernanceControlsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_governance_controls";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_governance_controls";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_governance_controls' is not enabled".to_string(),
@@ -284,7 +284,7 @@ impl GovernanceControlsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/governance/control",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -395,9 +395,9 @@ impl GovernanceControlsAPI {
         datadog::Error<UpdateGovernanceControlError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_governance_control";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_governance_control";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_governance_control' is not enabled".to_string(),
@@ -409,7 +409,7 @@ impl GovernanceControlsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/governance/control/{detection_type}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             detection_type = datadog::urlencode(detection_type)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_governance_insights.rs
+++ b/src/datadogV2/api/api_governance_insights.rs
@@ -165,9 +165,9 @@ impl GovernanceInsightsAPI {
         datadog::Error<ListGovernanceInsightsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_governance_insights";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_governance_insights";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_governance_insights' is not enabled".to_string(),
@@ -184,7 +184,7 @@ impl GovernanceInsightsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/governance/insights",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_high_availability_multi_region.rs
+++ b/src/datadogV2/api/api_high_availability_multi_region.rs
@@ -140,9 +140,9 @@ impl HighAvailabilityMultiRegionAPI {
         datadog::Error<CreateHamrOrgConnectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_hamr_org_connection";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_hamr_org_connection";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_hamr_org_connection' is not enabled".to_string(),
@@ -154,7 +154,7 @@ impl HighAvailabilityMultiRegionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/hamr",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -305,9 +305,9 @@ impl HighAvailabilityMultiRegionAPI {
         datadog::Error<GetHamrOrgConnectionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_hamr_org_connection";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_hamr_org_connection";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_hamr_org_connection' is not enabled".to_string(),
@@ -319,7 +319,7 @@ impl HighAvailabilityMultiRegionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/hamr",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_identity_providers.rs
+++ b/src/datadogV2/api/api_identity_providers.rs
@@ -243,7 +243,7 @@ impl IdentityProvidersAPI {
         datadog::Error<ListIdentityProviderUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_identity_provider_users";
+        let local_operation_id = "v2.list_identity_provider_users";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -257,7 +257,7 @@ impl IdentityProvidersAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/identity_providers/{idp_id}/users",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             idp_id = datadog::urlencode(idp_id)
         );
         let mut local_req_builder =
@@ -381,13 +381,13 @@ impl IdentityProvidersAPI {
         datadog::Error<ListIdentityProvidersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_identity_providers";
+        let local_operation_id = "v2.list_identity_providers";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/identity_providers",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -494,13 +494,13 @@ impl IdentityProvidersAPI {
         datadog::Error<UpdateIdentityProviderError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_identity_provider";
+        let local_operation_id = "v2.update_identity_provider";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/identity_providers/{idp_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             idp_id = datadog::urlencode(idp_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_incidents.rs
+++ b/src/datadogV2/api/api_incidents.rs
@@ -1229,9 +1229,9 @@ impl IncidentsAPI {
         datadog::Error<CreateGlobalIncidentHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_global_incident_handle";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_global_incident_handle";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_global_incident_handle' is not enabled".to_string(),
@@ -1246,7 +1246,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/global/incident-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1398,9 +1398,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident' is not enabled".to_string(),
@@ -1412,7 +1412,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1565,9 +1565,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentAttachmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_attachment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_attachment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_attachment' is not enabled".to_string(),
@@ -1582,7 +1582,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/attachments",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -1742,7 +1742,7 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentImpactError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_impact";
+        let local_operation_id = "v2.create_incident_impact";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1751,7 +1751,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/impacts",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -1918,9 +1918,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_integration";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_integration";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_integration' is not enabled".to_string(),
@@ -1932,7 +1932,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/integrations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -2085,9 +2085,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_notification_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_notification_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_notification_rule' is not enabled".to_string(),
@@ -2099,7 +2099,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2251,9 +2251,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentNotificationTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_notification_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_notification_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_notification_template' is not enabled"
@@ -2266,7 +2266,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2428,9 +2428,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentPostmortemAttachmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_postmortem_attachment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_postmortem_attachment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_postmortem_attachment' is not enabled"
@@ -2443,7 +2443,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/attachments/postmortems",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -2594,9 +2594,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentPostmortemTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_postmortem_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_postmortem_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_postmortem_template' is not enabled"
@@ -2609,7 +2609,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/postmortem-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2763,9 +2763,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentTodoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_todo";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_todo";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_todo' is not enabled".to_string(),
@@ -2777,7 +2777,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/todos",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -2927,9 +2927,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentTypeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_type";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_type";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_type' is not enabled".to_string(),
@@ -2941,7 +2941,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/types",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3095,9 +3095,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentUserDefinedFieldError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_user_defined_field";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_user_defined_field";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_user_defined_field' is not enabled".to_string(),
@@ -3112,7 +3112,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-fields",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3271,9 +3271,9 @@ impl IncidentsAPI {
         datadog::Error<CreateIncidentUserDefinedRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_user_defined_role";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_incident_user_defined_role";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_incident_user_defined_role' is not enabled".to_string(),
@@ -3288,7 +3288,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-roles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3426,9 +3426,9 @@ impl IncidentsAPI {
         &self,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteGlobalIncidentHandleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_global_incident_handle";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_global_incident_handle";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_global_incident_handle' is not enabled".to_string(),
@@ -3440,7 +3440,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/global/incident-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -3521,9 +3521,9 @@ impl IncidentsAPI {
         incident_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident' is not enabled".to_string(),
@@ -3535,7 +3535,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -3620,9 +3620,9 @@ impl IncidentsAPI {
         attachment_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentAttachmentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_attachment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_attachment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_attachment' is not enabled".to_string(),
@@ -3634,7 +3634,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/attachments/{attachment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id),
             attachment_id = datadog::urlencode(attachment_id)
         );
@@ -3722,13 +3722,13 @@ impl IncidentsAPI {
         impact_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentImpactError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_impact";
+        let local_operation_id = "v2.delete_incident_impact";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/impacts/{impact_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id),
             impact_id = datadog::urlencode(impact_id)
         );
@@ -3816,9 +3816,9 @@ impl IncidentsAPI {
         integration_metadata_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentIntegrationError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_integration";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_integration";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_integration' is not enabled".to_string(),
@@ -3830,7 +3830,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/integrations/{integration_metadata_id}",
-            local_configuration.get_operation_host(operation_id), incident_id=
+            local_configuration.get_operation_host(local_operation_id), incident_id=
             datadog::urlencode(incident_id)
             , integration_metadata_id=
             datadog::urlencode(integration_metadata_id)
@@ -3920,9 +3920,9 @@ impl IncidentsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentNotificationRuleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_notification_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_notification_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_notification_rule' is not enabled".to_string(),
@@ -3937,7 +3937,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -4030,9 +4030,9 @@ impl IncidentsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentNotificationTemplateError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_notification_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_notification_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_notification_template' is not enabled"
@@ -4048,7 +4048,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-templates/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -4139,9 +4139,9 @@ impl IncidentsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentPostmortemTemplateError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_postmortem_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_postmortem_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_postmortem_template' is not enabled"
@@ -4154,7 +4154,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/postmortem-templates/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id)
         );
         let mut local_req_builder =
@@ -4241,9 +4241,9 @@ impl IncidentsAPI {
         todo_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentTodoError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_todo";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_todo";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_todo' is not enabled".to_string(),
@@ -4255,7 +4255,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/todos/{todo_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id),
             todo_id = datadog::urlencode(todo_id)
         );
@@ -4341,9 +4341,9 @@ impl IncidentsAPI {
         incident_type_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentTypeError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_type";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_type";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_type' is not enabled".to_string(),
@@ -4355,7 +4355,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/types/{incident_type_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_type_id = datadog::urlencode(incident_type_id)
         );
         let mut local_req_builder =
@@ -4441,9 +4441,9 @@ impl IncidentsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentUserDefinedFieldError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_user_defined_field";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_user_defined_field";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_user_defined_field' is not enabled".to_string(),
@@ -4455,7 +4455,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-fields/{field_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             field_id = datadog::urlencode(field_id)
         );
         let mut local_req_builder =
@@ -4541,9 +4541,9 @@ impl IncidentsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentUserDefinedRoleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_user_defined_role";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_incident_user_defined_role";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_incident_user_defined_role' is not enabled".to_string(),
@@ -4555,7 +4555,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-roles/{role_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id.to_string())
         );
         let mut local_req_builder =
@@ -4649,9 +4649,9 @@ impl IncidentsAPI {
         datadog::Error<GetGlobalIncidentSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_global_incident_settings";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_global_incident_settings";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_global_incident_settings' is not enabled".to_string(),
@@ -4663,7 +4663,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/global/settings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4764,9 +4764,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident' is not enabled".to_string(),
@@ -4781,7 +4781,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -4899,9 +4899,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_integration";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_integration";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_integration' is not enabled".to_string(),
@@ -4913,7 +4913,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/integrations/{integration_metadata_id}",
-            local_configuration.get_operation_host(operation_id), incident_id=
+            local_configuration.get_operation_host(local_operation_id), incident_id=
             datadog::urlencode(incident_id)
             , integration_metadata_id=
             datadog::urlencode(integration_metadata_id)
@@ -5023,9 +5023,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_notification_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_notification_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_notification_rule' is not enabled".to_string(),
@@ -5040,7 +5040,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -5153,9 +5153,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentNotificationTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_notification_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_notification_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_notification_template' is not enabled".to_string(),
@@ -5170,7 +5170,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-templates/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -5281,9 +5281,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentPostmortemTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_postmortem_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_postmortem_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_postmortem_template' is not enabled".to_string(),
@@ -5295,7 +5295,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/postmortem-templates/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id)
         );
         let mut local_req_builder =
@@ -5401,9 +5401,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentTodoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_todo";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_todo";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_todo' is not enabled".to_string(),
@@ -5415,7 +5415,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/todos/{todo_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id),
             todo_id = datadog::urlencode(todo_id)
         );
@@ -5520,9 +5520,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentTypeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_type";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_type";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_type' is not enabled".to_string(),
@@ -5534,7 +5534,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/types/{incident_type_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_type_id = datadog::urlencode(incident_type_id)
         );
         let mut local_req_builder =
@@ -5642,9 +5642,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentUserDefinedFieldError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_user_defined_field";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_user_defined_field";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_user_defined_field' is not enabled".to_string(),
@@ -5659,7 +5659,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-fields/{field_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             field_id = datadog::urlencode(field_id)
         );
         let mut local_req_builder =
@@ -5772,9 +5772,9 @@ impl IncidentsAPI {
         datadog::Error<GetIncidentUserDefinedRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_user_defined_role";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_incident_user_defined_role";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_incident_user_defined_role' is not enabled".to_string(),
@@ -5789,7 +5789,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-roles/{role_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id.to_string())
         );
         let mut local_req_builder =
@@ -5901,9 +5901,9 @@ impl IncidentsAPI {
         datadog::Error<ImportIncidentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.import_incident";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.import_incident";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.import_incident' is not enabled".to_string(),
@@ -5918,7 +5918,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/import",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -6082,9 +6082,9 @@ impl IncidentsAPI {
         datadog::Error<ListGlobalIncidentHandlesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_global_incident_handles";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_global_incident_handles";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_global_incident_handles' is not enabled".to_string(),
@@ -6099,7 +6099,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/global/incident-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6211,9 +6211,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentAttachmentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_attachments";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_attachments";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_attachments' is not enabled".to_string(),
@@ -6229,7 +6229,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/attachments",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -6344,7 +6344,7 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentImpactsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_impacts";
+        let local_operation_id = "v2.list_incident_impacts";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -6353,7 +6353,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/impacts",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -6471,9 +6471,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentIntegrationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_integrations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_integrations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_integrations' is not enabled".to_string(),
@@ -6485,7 +6485,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/integrations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -6592,9 +6592,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentNotificationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_notification_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_notification_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_notification_rules' is not enabled".to_string(),
@@ -6609,7 +6609,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6719,9 +6719,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentNotificationTemplatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_notification_templates";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_notification_templates";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_notification_templates' is not enabled"
@@ -6738,7 +6738,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6852,9 +6852,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentPostmortemTemplatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_postmortem_templates";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_postmortem_templates";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_postmortem_templates' is not enabled".to_string(),
@@ -6870,7 +6870,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/postmortem-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6981,9 +6981,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentTodosError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_todos";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_todos";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_todos' is not enabled".to_string(),
@@ -6995,7 +6995,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/todos",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -7098,9 +7098,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentTypesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_types";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_types";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_types' is not enabled".to_string(),
@@ -7115,7 +7115,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/types",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7225,9 +7225,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentUserDefinedFieldsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_user_defined_fields";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_user_defined_fields";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_user_defined_fields' is not enabled".to_string(),
@@ -7246,7 +7246,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-fields",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7373,9 +7373,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentUserDefinedRolesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incident_user_defined_roles";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incident_user_defined_roles";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incident_user_defined_roles' is not enabled".to_string(),
@@ -7391,7 +7391,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-roles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7536,9 +7536,9 @@ impl IncidentsAPI {
         datadog::Error<ListIncidentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_incidents";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_incidents";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_incidents' is not enabled".to_string(),
@@ -7555,7 +7555,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7714,9 +7714,9 @@ impl IncidentsAPI {
         datadog::Error<SearchIncidentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_incidents";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.search_incidents";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.search_incidents' is not enabled".to_string(),
@@ -7734,7 +7734,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7859,9 +7859,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateGlobalIncidentHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_global_incident_handle";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_global_incident_handle";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_global_incident_handle' is not enabled".to_string(),
@@ -7876,7 +7876,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/global/incident-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -8033,9 +8033,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateGlobalIncidentSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_global_incident_settings";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_global_incident_settings";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_global_incident_settings' is not enabled".to_string(),
@@ -8047,7 +8047,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/global/settings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -8201,9 +8201,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident' is not enabled".to_string(),
@@ -8218,7 +8218,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id)
         );
         let mut local_req_builder =
@@ -8384,9 +8384,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentAttachmentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_attachment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_attachment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_attachment' is not enabled".to_string(),
@@ -8401,7 +8401,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/attachments/{attachment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id),
             attachment_id = datadog::urlencode(attachment_id)
         );
@@ -8562,9 +8562,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_integration";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_integration";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_integration' is not enabled".to_string(),
@@ -8576,7 +8576,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/integrations/{integration_metadata_id}",
-            local_configuration.get_operation_host(operation_id), incident_id=
+            local_configuration.get_operation_host(local_operation_id), incident_id=
             datadog::urlencode(incident_id)
             , integration_metadata_id=
             datadog::urlencode(integration_metadata_id)
@@ -8735,9 +8735,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_notification_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_notification_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_notification_rule' is not enabled".to_string(),
@@ -8752,7 +8752,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -8914,9 +8914,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentNotificationTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_notification_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_notification_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_notification_template' is not enabled"
@@ -8932,7 +8932,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/notification-templates/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id.to_string())
         );
         let mut local_req_builder =
@@ -9092,9 +9092,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentPostmortemTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_postmortem_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_postmortem_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_postmortem_template' is not enabled"
@@ -9107,7 +9107,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/postmortem-templates/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id)
         );
         let mut local_req_builder =
@@ -9264,9 +9264,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentTodoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_todo";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_todo";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_todo' is not enabled".to_string(),
@@ -9278,7 +9278,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/{incident_id}/relationships/todos/{todo_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_id = datadog::urlencode(incident_id),
             todo_id = datadog::urlencode(todo_id)
         );
@@ -9434,9 +9434,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentTypeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_type";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_type";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_type' is not enabled".to_string(),
@@ -9448,7 +9448,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/types/{incident_type_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_type_id = datadog::urlencode(incident_type_id)
         );
         let mut local_req_builder =
@@ -9605,9 +9605,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentUserDefinedFieldError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_user_defined_field";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_user_defined_field";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_user_defined_field' is not enabled".to_string(),
@@ -9622,7 +9622,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-fields/{field_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             field_id = datadog::urlencode(field_id)
         );
         let mut local_req_builder =
@@ -9784,9 +9784,9 @@ impl IncidentsAPI {
         datadog::Error<UpdateIncidentUserDefinedRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_user_defined_role";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_incident_user_defined_role";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_incident_user_defined_role' is not enabled".to_string(),
@@ -9801,7 +9801,7 @@ impl IncidentsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/incidents/config/user-defined-roles/{role_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_integrations.rs
+++ b/src/datadogV2/api/api_integrations.rs
@@ -115,13 +115,13 @@ impl IntegrationsAPI {
         datadog::Error<ListIntegrationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_integrations";
+        let local_operation_id = "v2.list_integrations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_ip_allowlist.rs
+++ b/src/datadogV2/api/api_ip_allowlist.rs
@@ -132,13 +132,13 @@ impl IPAllowlistAPI {
         datadog::Error<GetIPAllowlistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ip_allowlist";
+        let local_operation_id = "v2.get_ip_allowlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ip_allowlist",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -238,13 +238,13 @@ impl IPAllowlistAPI {
         datadog::Error<UpdateIPAllowlistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_ip_allowlist";
+        let local_operation_id = "v2.update_ip_allowlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ip_allowlist",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());

--- a/src/datadogV2/api/api_jira_integration.rs
+++ b/src/datadogV2/api/api_jira_integration.rs
@@ -177,9 +177,9 @@ impl JiraIntegrationAPI {
         datadog::Error<CreateJiraIssueTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_jira_issue_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_jira_issue_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_jira_issue_template' is not enabled".to_string(),
@@ -191,7 +191,7 @@ impl JiraIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/jira/issue-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -326,9 +326,9 @@ impl JiraIntegrationAPI {
         account_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteJiraAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_jira_account";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_jira_account";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_jira_account' is not enabled".to_string(),
@@ -340,7 +340,7 @@ impl JiraIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/jira/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id.to_string())
         );
         let mut local_req_builder =
@@ -425,9 +425,9 @@ impl JiraIntegrationAPI {
         issue_template_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteJiraIssueTemplateError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_jira_issue_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_jira_issue_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_jira_issue_template' is not enabled".to_string(),
@@ -439,7 +439,7 @@ impl JiraIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/jira/issue-templates/{issue_template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             issue_template_id = datadog::urlencode(issue_template_id.to_string())
         );
         let mut local_req_builder =
@@ -538,9 +538,9 @@ impl JiraIntegrationAPI {
         datadog::Error<GetJiraIssueTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_jira_issue_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_jira_issue_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_jira_issue_template' is not enabled".to_string(),
@@ -552,7 +552,7 @@ impl JiraIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/jira/issue-templates/{issue_template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             issue_template_id = datadog::urlencode(issue_template_id.to_string())
         );
         let mut local_req_builder =
@@ -651,9 +651,9 @@ impl JiraIntegrationAPI {
         datadog::Error<ListJiraAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_jira_accounts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_jira_accounts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_jira_accounts' is not enabled".to_string(),
@@ -665,7 +665,7 @@ impl JiraIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/jira/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -765,9 +765,9 @@ impl JiraIntegrationAPI {
         datadog::Error<ListJiraIssueTemplatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_jira_issue_templates";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_jira_issue_templates";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_jira_issue_templates' is not enabled".to_string(),
@@ -779,7 +779,7 @@ impl JiraIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/jira/issue-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -886,9 +886,9 @@ impl JiraIntegrationAPI {
         datadog::Error<UpdateJiraIssueTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_jira_issue_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_jira_issue_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_jira_issue_template' is not enabled".to_string(),
@@ -900,7 +900,7 @@ impl JiraIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/jira/issue-templates/{issue_template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             issue_template_id = datadog::urlencode(issue_template_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_key_management.rs
+++ b/src/datadogV2/api/api_key_management.rs
@@ -589,13 +589,13 @@ impl KeyManagementAPI {
         datadog::Error<CreateAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_api_key";
+        let local_operation_id = "v2.create_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/api_keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -744,13 +744,13 @@ impl KeyManagementAPI {
         datadog::Error<CreateCurrentUserApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_current_user_application_key";
+        let local_operation_id = "v2.create_current_user_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/current_user/application_keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -899,13 +899,13 @@ impl KeyManagementAPI {
         datadog::Error<CreatePersonalAccessTokenError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_personal_access_token";
+        let local_operation_id = "v2.create_personal_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/personal_access_tokens",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1040,13 +1040,13 @@ impl KeyManagementAPI {
         api_key_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAPIKeyError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_api_key";
+        let local_operation_id = "v2.delete_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/api_keys/{api_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             api_key_id = datadog::urlencode(api_key_id)
         );
         let mut local_req_builder =
@@ -1127,13 +1127,13 @@ impl KeyManagementAPI {
         app_key_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteApplicationKeyError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_application_key";
+        let local_operation_id = "v2.delete_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -1219,13 +1219,13 @@ impl KeyManagementAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCurrentUserApplicationKeyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_current_user_application_key";
+        let local_operation_id = "v2.delete_current_user_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/current_user/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -1320,7 +1320,7 @@ impl KeyManagementAPI {
         datadog::Error<GetAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_api_key";
+        let local_operation_id = "v2.get_api_key";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1329,7 +1329,7 @@ impl KeyManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/api_keys/{api_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             api_key_id = datadog::urlencode(api_key_id)
         );
         let mut local_req_builder =
@@ -1439,7 +1439,7 @@ impl KeyManagementAPI {
         datadog::Error<GetApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_application_key";
+        let local_operation_id = "v2.get_application_key";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1448,7 +1448,7 @@ impl KeyManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -1561,13 +1561,13 @@ impl KeyManagementAPI {
         datadog::Error<GetCurrentUserApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_current_user_application_key";
+        let local_operation_id = "v2.get_current_user_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/current_user/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -1673,13 +1673,13 @@ impl KeyManagementAPI {
         datadog::Error<GetPersonalAccessTokenError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_personal_access_token";
+        let local_operation_id = "v2.get_personal_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/personal_access_tokens/{token_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token_id = datadog::urlencode(token_id)
         );
         let mut local_req_builder =
@@ -1779,7 +1779,7 @@ impl KeyManagementAPI {
         datadog::Error<ListAPIKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_api_keys";
+        let local_operation_id = "v2.list_api_keys";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1798,7 +1798,7 @@ impl KeyManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/api_keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1944,7 +1944,7 @@ impl KeyManagementAPI {
         datadog::Error<ListApplicationKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_application_keys";
+        let local_operation_id = "v2.list_application_keys";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1960,7 +1960,7 @@ impl KeyManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/application_keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2098,7 +2098,7 @@ impl KeyManagementAPI {
         datadog::Error<ListCurrentUserApplicationKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_current_user_application_keys";
+        let local_operation_id = "v2.list_current_user_application_keys";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -2113,7 +2113,7 @@ impl KeyManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/current_user/application_keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2247,7 +2247,7 @@ impl KeyManagementAPI {
         datadog::Error<ListPersonalAccessTokensError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_personal_access_tokens";
+        let local_operation_id = "v2.list_personal_access_tokens";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -2260,7 +2260,7 @@ impl KeyManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/personal_access_tokens",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2374,13 +2374,13 @@ impl KeyManagementAPI {
         token_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RevokePersonalAccessTokenError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.revoke_personal_access_token";
+        let local_operation_id = "v2.revoke_personal_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/personal_access_tokens/{token_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token_id = datadog::urlencode(token_id)
         );
         let mut local_req_builder =
@@ -2475,13 +2475,13 @@ impl KeyManagementAPI {
         datadog::Error<UpdateAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_api_key";
+        let local_operation_id = "v2.update_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/api_keys/{api_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             api_key_id = datadog::urlencode(api_key_id)
         );
         let mut local_req_builder =
@@ -2633,13 +2633,13 @@ impl KeyManagementAPI {
         datadog::Error<UpdateApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_application_key";
+        let local_operation_id = "v2.update_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -2796,13 +2796,13 @@ impl KeyManagementAPI {
         datadog::Error<UpdateCurrentUserApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_current_user_application_key";
+        let local_operation_id = "v2.update_current_user_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/current_user/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
         let mut local_req_builder =
@@ -2957,13 +2957,13 @@ impl KeyManagementAPI {
         datadog::Error<UpdatePersonalAccessTokenError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_personal_access_token";
+        let local_operation_id = "v2.update_personal_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/personal_access_tokens/{token_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             token_id = datadog::urlencode(token_id)
         );
         let mut local_req_builder =
@@ -3108,9 +3108,9 @@ impl KeyManagementAPI {
         datadog::Error<ValidateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.validate";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.validate' is not enabled".to_string(),
@@ -3122,7 +3122,7 @@ impl KeyManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3218,13 +3218,13 @@ impl KeyManagementAPI {
         datadog::Error<ValidateAPIKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_api_key";
+        let local_operation_id = "v2.validate_api_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/validate_keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_llm_observability.rs
+++ b/src/datadogV2/api/api_llm_observability.rs
@@ -1310,9 +1310,9 @@ impl LLMObservabilityAPI {
         datadog::Error<AggregateLLMObsExperimentationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.aggregate_llm_obs_experimentation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.aggregate_llm_obs_experimentation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.aggregate_llm_obs_experimentation' is not enabled".to_string(),
@@ -1324,7 +1324,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experimentation/analytics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1481,9 +1481,9 @@ impl LLMObservabilityAPI {
         datadog::Error<BatchUpdateLLMObsDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.batch_update_llm_obs_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.batch_update_llm_obs_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.batch_update_llm_obs_dataset' is not enabled".to_string(),
@@ -1495,7 +1495,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/batch_update",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -1654,9 +1654,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CloneLLMObsDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.clone_llm_obs_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.clone_llm_obs_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.clone_llm_obs_dataset' is not enabled".to_string(),
@@ -1668,7 +1668,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/clone",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -1828,9 +1828,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsAnnotationQueueError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_annotation_queue";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_annotation_queue";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_annotation_queue' is not enabled".to_string(),
@@ -1842,7 +1842,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2016,9 +2016,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsAnnotationQueueInteractionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_annotation_queue_interactions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_annotation_queue_interactions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_annotation_queue_interactions' is not enabled"
@@ -2031,7 +2031,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}/interactions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -2187,9 +2187,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_dataset' is not enabled".to_string(),
@@ -2201,7 +2201,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -2358,9 +2358,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsDatasetRecordsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_dataset_records";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_dataset_records";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_dataset_records' is not enabled".to_string(),
@@ -2372,7 +2372,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/records",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -2524,9 +2524,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsExperimentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_experiment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_experiment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_experiment' is not enabled".to_string(),
@@ -2538,7 +2538,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experiments",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2679,9 +2679,9 @@ impl LLMObservabilityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateLLMObsExperimentEventsError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_experiment_events";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_experiment_events";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_experiment_events' is not enabled".to_string(),
@@ -2693,7 +2693,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experiments/{experiment_id}/events",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experiment_id = datadog::urlencode(experiment_id)
         );
         let mut local_req_builder =
@@ -2843,9 +2843,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsIntegrationInferenceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_integration_inference";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_integration_inference";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_integration_inference' is not enabled"
@@ -2858,7 +2858,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/integrations/{integration}/{account_id}/inference",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration = datadog::urlencode(integration.to_string()),
             account_id = datadog::urlencode(account_id)
         );
@@ -3009,9 +3009,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsProjectError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_project";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_project";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_project' is not enabled".to_string(),
@@ -3023,7 +3023,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/projects",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3172,9 +3172,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsPromptError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_prompt";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_prompt";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_prompt' is not enabled".to_string(),
@@ -3186,7 +3186,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3340,9 +3340,9 @@ impl LLMObservabilityAPI {
         datadog::Error<CreateLLMObsPromptVersionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_llm_obs_prompt_version";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_llm_obs_prompt_version";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_llm_obs_prompt_version' is not enabled".to_string(),
@@ -3354,7 +3354,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts/{prompt_id}/versions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             prompt_id = datadog::urlencode(prompt_id)
         );
         let mut local_req_builder =
@@ -3494,9 +3494,9 @@ impl LLMObservabilityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLLMObsAnnotationQueueError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_annotation_queue";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_annotation_queue";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_annotation_queue' is not enabled".to_string(),
@@ -3508,7 +3508,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -3598,9 +3598,9 @@ impl LLMObservabilityAPI {
         datadog::Error<DeleteLLMObsAnnotationQueueInteractionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_annotation_queue_interactions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_annotation_queue_interactions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_annotation_queue_interactions' is not enabled"
@@ -3613,7 +3613,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}/interactions/delete",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -3761,9 +3761,9 @@ impl LLMObservabilityAPI {
         datadog::Error<DeleteLLMObsAnnotationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_annotations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_annotations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_annotations' is not enabled".to_string(),
@@ -3775,7 +3775,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotations/delete",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -3915,9 +3915,9 @@ impl LLMObservabilityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLLMObsCustomEvalConfigError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_custom_eval_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_custom_eval_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_custom_eval_config' is not enabled".to_string(),
@@ -3929,7 +3929,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/llm-obs/config/evaluators/custom/{eval_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             eval_name = datadog::urlencode(eval_name)
         );
         let mut local_req_builder =
@@ -4025,9 +4025,9 @@ impl LLMObservabilityAPI {
         datadog::Error<DeleteLLMObsDataError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_data";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_data";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_data' is not enabled".to_string(),
@@ -4039,7 +4039,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/deletion/data/llmobs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4181,9 +4181,9 @@ impl LLMObservabilityAPI {
         body: crate::datadogV2::model::LLMObsDeleteDatasetRecordsRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLLMObsDatasetRecordsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_dataset_records";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_dataset_records";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_dataset_records' is not enabled".to_string(),
@@ -4195,7 +4195,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/records/delete",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -4330,9 +4330,9 @@ impl LLMObservabilityAPI {
         body: crate::datadogV2::model::LLMObsDeleteDatasetsRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLLMObsDatasetsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_datasets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_datasets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_datasets' is not enabled".to_string(),
@@ -4344,7 +4344,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/delete",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -4473,9 +4473,9 @@ impl LLMObservabilityAPI {
         body: crate::datadogV2::model::LLMObsDeleteExperimentsRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLLMObsExperimentsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_experiments";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_experiments";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_experiments' is not enabled".to_string(),
@@ -4487,7 +4487,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experiments/delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4618,9 +4618,9 @@ impl LLMObservabilityAPI {
         config_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLLMObsPatternsConfigError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_patterns_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_patterns_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_patterns_config' is not enabled".to_string(),
@@ -4632,7 +4632,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-configs/{config_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             config_id = datadog::urlencode(config_id)
         );
         let mut local_req_builder =
@@ -4714,9 +4714,9 @@ impl LLMObservabilityAPI {
         body: crate::datadogV2::model::LLMObsDeleteProjectsRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLLMObsProjectsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_projects";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_projects";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_projects' is not enabled".to_string(),
@@ -4728,7 +4728,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/projects/delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4870,9 +4870,9 @@ impl LLMObservabilityAPI {
         datadog::Error<DeleteLLMObsPromptError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_llm_obs_prompt";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_llm_obs_prompt";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_llm_obs_prompt' is not enabled".to_string(),
@@ -4884,7 +4884,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts/{prompt_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             prompt_id = datadog::urlencode(prompt_id)
         );
         let mut local_req_builder =
@@ -4988,9 +4988,9 @@ impl LLMObservabilityAPI {
         params: ExportLLMObsDatasetOptionalParams,
     ) -> Result<datadog::ResponseContent<String>, datadog::Error<ExportLLMObsDatasetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.export_llm_obs_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.export_llm_obs_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.export_llm_obs_dataset' is not enabled".to_string(),
@@ -5006,7 +5006,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/export",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -5120,9 +5120,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsAnnotatedInteractionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_annotated_interactions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_annotated_interactions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_annotated_interactions' is not enabled".to_string(),
@@ -5134,7 +5134,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotated-interactions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -5246,9 +5246,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsAnnotatedInteractionsByTraceIDsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_annotated_interactions_by_trace_i_ds";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_annotated_interactions_by_trace_i_ds";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg:
@@ -5266,7 +5266,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotated-interactions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5390,9 +5390,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsAnnotationQueueLabelSchemaError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_annotation_queue_label_schema";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_annotation_queue_label_schema";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_annotation_queue_label_schema' is not enabled"
@@ -5405,7 +5405,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}/label-schema",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -5512,9 +5512,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsCustomEvalConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_custom_eval_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_custom_eval_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_custom_eval_config' is not enabled".to_string(),
@@ -5526,7 +5526,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/llm-obs/config/evaluators/custom/{eval_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             eval_name = datadog::urlencode(eval_name)
         );
         let mut local_req_builder =
@@ -5634,9 +5634,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsDatasetDraftStateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_dataset_draft_state";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_dataset_draft_state";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_dataset_draft_state' is not enabled".to_string(),
@@ -5648,7 +5648,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/draft_state",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -5750,9 +5750,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsPatternsConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_patterns_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_patterns_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_patterns_config' is not enabled".to_string(),
@@ -5764,7 +5764,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-configs/latest",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5871,9 +5871,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsPatternsRunStatusError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_patterns_run_status";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_patterns_run_status";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_patterns_run_status' is not enabled".to_string(),
@@ -5885,7 +5885,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-runs/status",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -5994,9 +5994,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsPromptError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_prompt";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_prompt";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_prompt' is not enabled".to_string(),
@@ -6011,7 +6011,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts/{prompt_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             prompt_id = datadog::urlencode(prompt_id)
         );
         let mut local_req_builder =
@@ -6124,9 +6124,9 @@ impl LLMObservabilityAPI {
         datadog::Error<GetLLMObsPromptVersionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_llm_obs_prompt_version";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_llm_obs_prompt_version";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_llm_obs_prompt_version' is not enabled".to_string(),
@@ -6138,7 +6138,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts/{prompt_id}/versions/{version}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             prompt_id = datadog::urlencode(prompt_id),
             version = version
         );
@@ -6247,9 +6247,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsAnnotationQueuesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_annotation_queues";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_annotation_queues";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_annotation_queues' is not enabled".to_string(),
@@ -6265,7 +6265,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6375,9 +6375,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsCustomEvalConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_custom_eval_configs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_custom_eval_configs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_custom_eval_configs' is not enabled".to_string(),
@@ -6389,7 +6389,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/llm-obs/config/evaluators/custom",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -6498,9 +6498,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsDatasetRecordsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_dataset_records";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_dataset_records";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_dataset_records' is not enabled".to_string(),
@@ -6517,7 +6517,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/records",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -6639,9 +6639,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsDatasetVersionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_dataset_versions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_dataset_versions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_dataset_versions' is not enabled".to_string(),
@@ -6653,7 +6653,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/versions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -6762,9 +6762,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsDatasetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_datasets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_datasets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_datasets' is not enabled".to_string(),
@@ -6782,7 +6782,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -6907,9 +6907,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsExperimentEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_experiment_events";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_experiment_events";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_experiment_events' is not enabled".to_string(),
@@ -6925,7 +6925,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v3/experiments/{experiment_id}/events",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experiment_id = datadog::urlencode(experiment_id)
         );
         let mut local_req_builder =
@@ -7040,9 +7040,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsExperimentEventsV1Error>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_experiment_events_v1";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_experiment_events_v1";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_experiment_events_v1' is not enabled".to_string(),
@@ -7054,7 +7054,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experiments/{experiment_id}/events",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experiment_id = datadog::urlencode(experiment_id)
         );
         let mut local_req_builder =
@@ -7160,9 +7160,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsExperimentEventsV2Error>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_experiment_events_v2";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_experiment_events_v2";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_experiment_events_v2' is not enabled".to_string(),
@@ -7174,7 +7174,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v2/experiments/{experiment_id}/events",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experiment_id = datadog::urlencode(experiment_id)
         );
         let mut local_req_builder =
@@ -7277,9 +7277,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsExperimentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_experiments";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_experiments";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_experiments' is not enabled".to_string(),
@@ -7305,7 +7305,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experiments",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7461,9 +7461,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsIntegrationAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_integration_accounts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_integration_accounts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_integration_accounts' is not enabled".to_string(),
@@ -7475,7 +7475,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/integrations/{integration}/accounts",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration = datadog::urlencode(integration.to_string())
         );
         let mut local_req_builder =
@@ -7583,9 +7583,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsIntegrationModelsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_integration_models";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_integration_models";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_integration_models' is not enabled".to_string(),
@@ -7597,7 +7597,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/integrations/{integration}/{account_id}/models",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration = datadog::urlencode(integration.to_string()),
             account_id = datadog::urlencode(account_id)
         );
@@ -7708,9 +7708,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsPatternsClusteredPointsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_patterns_clustered_points";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_patterns_clustered_points";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_patterns_clustered_points' is not enabled"
@@ -7727,7 +7727,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-clustered-points",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7838,9 +7838,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsPatternsConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_patterns_configs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_patterns_configs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_patterns_configs' is not enabled".to_string(),
@@ -7852,7 +7852,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-configs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -7957,9 +7957,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsPatternsRunsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_patterns_runs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_patterns_runs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_patterns_runs' is not enabled".to_string(),
@@ -7971,7 +7971,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-runs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -8082,9 +8082,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsPatternsTopicsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_patterns_topics";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_patterns_topics";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_patterns_topics' is not enabled".to_string(),
@@ -8099,7 +8099,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-topics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -8218,9 +8218,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsPatternsTopicsWithClusteredPointsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_patterns_topics_with_clustered_points";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_patterns_topics_with_clustered_points";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_patterns_topics_with_clustered_points' is not enabled".to_string(),
@@ -8236,7 +8236,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-topics/with-cluster-points",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -8349,9 +8349,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsProjectsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_projects";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_projects";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_projects' is not enabled".to_string(),
@@ -8369,7 +8369,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/projects",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -8491,9 +8491,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsPromptVersionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_prompt_versions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_prompt_versions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_prompt_versions' is not enabled".to_string(),
@@ -8505,7 +8505,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts/{prompt_id}/versions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             prompt_id = datadog::urlencode(prompt_id)
         );
         let mut local_req_builder =
@@ -8608,9 +8608,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsPromptsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_prompts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_prompts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_prompts' is not enabled".to_string(),
@@ -8625,7 +8625,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -8730,9 +8730,9 @@ impl LLMObservabilityAPI {
         datadog::Error<ListLLMObsSpansError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_llm_obs_spans";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_llm_obs_spans";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_llm_obs_spans' is not enabled".to_string(),
@@ -8758,7 +8758,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/spans/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -8914,9 +8914,9 @@ impl LLMObservabilityAPI {
         datadog::Error<LockLLMObsDatasetDraftStateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.lock_llm_obs_dataset_draft_state";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.lock_llm_obs_dataset_draft_state";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.lock_llm_obs_dataset_draft_state' is not enabled".to_string(),
@@ -8928,7 +8928,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/draft_state/lock",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -9026,9 +9026,9 @@ impl LLMObservabilityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RestoreLLMObsDatasetVersionError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.restore_llm_obs_dataset_version";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.restore_llm_obs_dataset_version";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.restore_llm_obs_dataset_version' is not enabled".to_string(),
@@ -9040,7 +9040,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/restore",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -9195,9 +9195,9 @@ impl LLMObservabilityAPI {
         datadog::Error<SearchLLMObsExperimentationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_llm_obs_experimentation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.search_llm_obs_experimentation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.search_llm_obs_experimentation' is not enabled".to_string(),
@@ -9209,7 +9209,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experimentation/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -9356,9 +9356,9 @@ impl LLMObservabilityAPI {
         datadog::Error<SearchLLMObsSpansError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_llm_obs_spans";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.search_llm_obs_spans";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.search_llm_obs_spans' is not enabled".to_string(),
@@ -9370,7 +9370,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/spans/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -9530,9 +9530,9 @@ impl LLMObservabilityAPI {
         datadog::Error<SimpleSearchLLMObsExperimentationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.simple_search_llm_obs_experimentation";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.simple_search_llm_obs_experimentation";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.simple_search_llm_obs_experimentation' is not enabled"
@@ -9545,7 +9545,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experimentation/simple-search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -9695,9 +9695,9 @@ impl LLMObservabilityAPI {
         datadog::Error<TriggerLLMObsPatternsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.trigger_llm_obs_patterns";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.trigger_llm_obs_patterns";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.trigger_llm_obs_patterns' is not enabled".to_string(),
@@ -9709,7 +9709,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-runs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -9850,9 +9850,9 @@ impl LLMObservabilityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnlockLLMObsDatasetDraftStateError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.unlock_llm_obs_dataset_draft_state";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.unlock_llm_obs_dataset_draft_state";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.unlock_llm_obs_dataset_draft_state' is not enabled".to_string(),
@@ -9864,7 +9864,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/draft_state/unlock",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -9966,9 +9966,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsAnnotationQueueError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_annotation_queue";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_annotation_queue";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_annotation_queue' is not enabled".to_string(),
@@ -9980,7 +9980,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -10141,9 +10141,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsAnnotationQueueLabelSchemaError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_annotation_queue_label_schema";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_annotation_queue_label_schema";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_annotation_queue_label_schema' is not enabled"
@@ -10156,7 +10156,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}/label-schema",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -10299,9 +10299,9 @@ impl LLMObservabilityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateLLMObsCustomEvalConfigError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_custom_eval_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_custom_eval_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_custom_eval_config' is not enabled".to_string(),
@@ -10313,7 +10313,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/unstable/llm-obs/config/evaluators/custom/{eval_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             eval_name = datadog::urlencode(eval_name)
         );
         let mut local_req_builder =
@@ -10463,9 +10463,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_dataset' is not enabled".to_string(),
@@ -10477,7 +10477,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -10635,9 +10635,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsDatasetRecordsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_dataset_records";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_dataset_records";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_dataset_records' is not enabled".to_string(),
@@ -10649,7 +10649,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/{project_id}/datasets/{dataset_id}/records",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -10806,9 +10806,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsExperimentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_experiment";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_experiment";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_experiment' is not enabled".to_string(),
@@ -10820,7 +10820,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/experiments/{experiment_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experiment_id = datadog::urlencode(experiment_id)
         );
         let mut local_req_builder =
@@ -10975,9 +10975,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsProjectError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_project";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_project";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_project' is not enabled".to_string(),
@@ -10989,7 +10989,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/projects/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id)
         );
         let mut local_req_builder =
@@ -11144,9 +11144,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsPromptError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_prompt";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_prompt";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_prompt' is not enabled".to_string(),
@@ -11158,7 +11158,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts/{prompt_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             prompt_id = datadog::urlencode(prompt_id)
         );
         let mut local_req_builder =
@@ -11315,9 +11315,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpdateLLMObsPromptVersionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_llm_obs_prompt_version";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_llm_obs_prompt_version";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_llm_obs_prompt_version' is not enabled".to_string(),
@@ -11329,7 +11329,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/prompts/{prompt_id}/versions/{version}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             prompt_id = datadog::urlencode(prompt_id),
             version = version
         );
@@ -11486,9 +11486,9 @@ impl LLMObservabilityAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UploadLLMObsDatasetRecordsFileError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.upload_llm_obs_dataset_records_file";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.upload_llm_obs_dataset_records_file";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.upload_llm_obs_dataset_records_file' is not enabled"
@@ -11508,7 +11508,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v2/{project_id}/datasets/{dataset_id}/records/upload",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = datadog::urlencode(project_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
@@ -11661,9 +11661,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpsertLLMObsAnnotationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_llm_obs_annotations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.upsert_llm_obs_annotations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.upsert_llm_obs_annotations' is not enabled".to_string(),
@@ -11675,7 +11675,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/annotation-queues/{queue_id}/annotations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             queue_id = datadog::urlencode(queue_id)
         );
         let mut local_req_builder =
@@ -11828,9 +11828,9 @@ impl LLMObservabilityAPI {
         datadog::Error<UpsertLLMObsPatternsConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_llm_obs_patterns_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.upsert_llm_obs_patterns_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.upsert_llm_obs_patterns_config' is not enabled".to_string(),
@@ -11842,7 +11842,7 @@ impl LLMObservabilityAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/llm-obs/v1/topic-discovery-configs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV2/api/api_logs.rs
+++ b/src/datadogV2/api/api_logs.rs
@@ -251,13 +251,13 @@ impl LogsAPI {
         datadog::Error<AggregateLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.aggregate_logs";
+        let local_operation_id = "v2.aggregate_logs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/analytics/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -462,7 +462,7 @@ impl LogsAPI {
         datadog::Error<ListLogsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_logs";
+        let local_operation_id = "v2.list_logs";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -471,7 +471,7 @@ impl LogsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -668,7 +668,7 @@ impl LogsAPI {
         datadog::Error<ListLogsGetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_logs_get";
+        let local_operation_id = "v2.list_logs_get";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -684,7 +684,7 @@ impl LogsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -874,7 +874,7 @@ impl LogsAPI {
         datadog::Error<SubmitLogError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.submit_log";
+        let local_operation_id = "v2.submit_log";
 
         // unbox and build optional parameters
         let content_encoding = params.content_encoding;
@@ -884,7 +884,7 @@ impl LogsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_logs_archives.rs
+++ b/src/datadogV2/api/api_logs_archives.rs
@@ -189,13 +189,13 @@ impl LogsArchivesAPI {
         body: crate::datadogV2::model::RelationshipToRole,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<AddReadRoleToArchiveError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_read_role_to_archive";
+        let local_operation_id = "v2.add_read_role_to_archive";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives/{archive_id}/readers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             archive_id = datadog::urlencode(archive_id)
         );
         let mut local_req_builder =
@@ -335,13 +335,13 @@ impl LogsArchivesAPI {
         datadog::Error<CreateLogsArchiveError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_logs_archive";
+        let local_operation_id = "v2.create_logs_archive";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -474,13 +474,13 @@ impl LogsArchivesAPI {
         archive_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLogsArchiveError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_logs_archive";
+        let local_operation_id = "v2.delete_logs_archive";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives/{archive_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             archive_id = datadog::urlencode(archive_id)
         );
         let mut local_req_builder =
@@ -573,13 +573,13 @@ impl LogsArchivesAPI {
         datadog::Error<GetLogsArchiveError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_logs_archive";
+        let local_operation_id = "v2.get_logs_archive";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives/{archive_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             archive_id = datadog::urlencode(archive_id)
         );
         let mut local_req_builder =
@@ -678,13 +678,13 @@ impl LogsArchivesAPI {
         datadog::Error<GetLogsArchiveOrderError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_logs_archive_order";
+        let local_operation_id = "v2.get_logs_archive_order";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archive-order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -786,13 +786,13 @@ impl LogsArchivesAPI {
         datadog::Error<ListArchiveReadRolesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_archive_read_roles";
+        let local_operation_id = "v2.list_archive_read_roles";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives/{archive_id}/readers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             archive_id = datadog::urlencode(archive_id)
         );
         let mut local_req_builder =
@@ -888,13 +888,13 @@ impl LogsArchivesAPI {
         datadog::Error<ListLogsArchivesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_logs_archives";
+        let local_operation_id = "v2.list_logs_archives";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -985,13 +985,13 @@ impl LogsArchivesAPI {
         body: crate::datadogV2::model::RelationshipToRole,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RemoveRoleFromArchiveError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_role_from_archive";
+        let local_operation_id = "v2.remove_role_from_archive";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives/{archive_id}/readers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             archive_id = datadog::urlencode(archive_id)
         );
         let mut local_req_builder =
@@ -1142,13 +1142,13 @@ impl LogsArchivesAPI {
         datadog::Error<UpdateLogsArchiveError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_logs_archive";
+        let local_operation_id = "v2.update_logs_archive";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archives/{archive_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             archive_id = datadog::urlencode(archive_id)
         );
         let mut local_req_builder =
@@ -1304,13 +1304,13 @@ impl LogsArchivesAPI {
         datadog::Error<UpdateLogsArchiveOrderError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_logs_archive_order";
+        let local_operation_id = "v2.update_logs_archive_order";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/archive-order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV2/api/api_logs_custom_destinations.rs
+++ b/src/datadogV2/api/api_logs_custom_destinations.rs
@@ -163,13 +163,13 @@ impl LogsCustomDestinationsAPI {
         datadog::Error<CreateLogsCustomDestinationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_logs_custom_destination";
+        let local_operation_id = "v2.create_logs_custom_destination";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/custom-destinations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -308,13 +308,13 @@ impl LogsCustomDestinationsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLogsCustomDestinationError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_logs_custom_destination";
+        let local_operation_id = "v2.delete_logs_custom_destination";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/custom-destinations/{custom_destination_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_destination_id = datadog::urlencode(custom_destination_id)
         );
         let mut local_req_builder =
@@ -413,13 +413,13 @@ impl LogsCustomDestinationsAPI {
         datadog::Error<GetLogsCustomDestinationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_logs_custom_destination";
+        let local_operation_id = "v2.get_logs_custom_destination";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/custom-destinations/{custom_destination_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_destination_id = datadog::urlencode(custom_destination_id)
         );
         let mut local_req_builder =
@@ -520,13 +520,13 @@ impl LogsCustomDestinationsAPI {
         datadog::Error<ListLogsCustomDestinationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_logs_custom_destinations";
+        let local_operation_id = "v2.list_logs_custom_destinations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/custom-destinations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -633,13 +633,13 @@ impl LogsCustomDestinationsAPI {
         datadog::Error<UpdateLogsCustomDestinationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_logs_custom_destination";
+        let local_operation_id = "v2.update_logs_custom_destination";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/custom-destinations/{custom_destination_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             custom_destination_id = datadog::urlencode(custom_destination_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_logs_metrics.rs
+++ b/src/datadogV2/api/api_logs_metrics.rs
@@ -155,13 +155,13 @@ impl LogsMetricsAPI {
         datadog::Error<CreateLogsMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_logs_metric";
+        let local_operation_id = "v2.create_logs_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -296,13 +296,13 @@ impl LogsMetricsAPI {
         metric_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteLogsMetricError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_logs_metric";
+        let local_operation_id = "v2.delete_logs_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =
@@ -396,13 +396,13 @@ impl LogsMetricsAPI {
         datadog::Error<GetLogsMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_logs_metric";
+        let local_operation_id = "v2.get_logs_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =
@@ -501,13 +501,13 @@ impl LogsMetricsAPI {
         datadog::Error<ListLogsMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_logs_metrics";
+        let local_operation_id = "v2.list_logs_metrics";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -614,13 +614,13 @@ impl LogsMetricsAPI {
         datadog::Error<UpdateLogsMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_logs_metric";
+        let local_operation_id = "v2.update_logs_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_logs_restriction_queries.rs
+++ b/src/datadogV2/api/api_logs_restriction_queries.rs
@@ -260,9 +260,9 @@ impl LogsRestrictionQueriesAPI {
         body: crate::datadogV2::model::RelationshipToRole,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<AddRoleToRestrictionQueryError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_role_to_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.add_role_to_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.add_role_to_restriction_query' is not enabled".to_string(),
@@ -274,7 +274,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/{restriction_query_id}/roles",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             restriction_query_id = datadog::urlencode(restriction_query_id)
         );
         let mut local_req_builder =
@@ -419,9 +419,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<CreateRestrictionQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_restriction_query' is not enabled".to_string(),
@@ -433,7 +433,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -572,9 +572,9 @@ impl LogsRestrictionQueriesAPI {
         restriction_query_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRestrictionQueryError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_restriction_query' is not enabled".to_string(),
@@ -586,7 +586,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/{restriction_query_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             restriction_query_id = datadog::urlencode(restriction_query_id)
         );
         let mut local_req_builder =
@@ -687,9 +687,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<GetRestrictionQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_restriction_query' is not enabled".to_string(),
@@ -701,7 +701,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/{restriction_query_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             restriction_query_id = datadog::urlencode(restriction_query_id)
         );
         let mut local_req_builder =
@@ -808,9 +808,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<GetRoleRestrictionQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_role_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_role_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_role_restriction_query' is not enabled".to_string(),
@@ -822,7 +822,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/role/{role_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -925,9 +925,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<ListRestrictionQueriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_restriction_queries";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_restriction_queries";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_restriction_queries' is not enabled".to_string(),
@@ -943,7 +943,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1059,9 +1059,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<ListRestrictionQueryRolesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_restriction_query_roles";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_restriction_query_roles";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_restriction_query_roles' is not enabled".to_string(),
@@ -1077,7 +1077,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/{restriction_query_id}/roles",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             restriction_query_id = datadog::urlencode(restriction_query_id)
         );
         let mut local_req_builder =
@@ -1192,9 +1192,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<ListUserRestrictionQueriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_user_restriction_queries";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_user_restriction_queries";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_user_restriction_queries' is not enabled".to_string(),
@@ -1206,7 +1206,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/user/{user_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -1301,9 +1301,9 @@ impl LogsRestrictionQueriesAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RemoveRoleFromRestrictionQueryError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_role_from_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.remove_role_from_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.remove_role_from_restriction_query' is not enabled".to_string(),
@@ -1315,7 +1315,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/{restriction_query_id}/roles",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             restriction_query_id = datadog::urlencode(restriction_query_id)
         );
         let mut local_req_builder =
@@ -1465,9 +1465,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<ReplaceRestrictionQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.replace_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.replace_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.replace_restriction_query' is not enabled".to_string(),
@@ -1479,7 +1479,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/{restriction_query_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             restriction_query_id = datadog::urlencode(restriction_query_id)
         );
         let mut local_req_builder =
@@ -1637,9 +1637,9 @@ impl LogsRestrictionQueriesAPI {
         datadog::Error<UpdateRestrictionQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_restriction_query";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_restriction_query";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_restriction_query' is not enabled".to_string(),
@@ -1651,7 +1651,7 @@ impl LogsRestrictionQueriesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/logs/config/restriction_queries/{restriction_query_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             restriction_query_id = datadog::urlencode(restriction_query_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_metrics.rs
+++ b/src/datadogV2/api/api_metrics.rs
@@ -660,13 +660,13 @@ impl MetricsAPI {
         datadog::Error<CreateBulkTagsMetricsConfigurationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_bulk_tags_metrics_configuration";
+        let local_operation_id = "v2.create_bulk_tags_metrics_configuration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/config/bulk-tags",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -828,13 +828,13 @@ impl MetricsAPI {
         datadog::Error<CreateTagConfigurationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_tag_configuration";
+        let local_operation_id = "v2.create_tag_configuration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tags",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -988,9 +988,9 @@ impl MetricsAPI {
         datadog::Error<CreateTagIndexingRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_tag_indexing_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_tag_indexing_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_tag_indexing_rule' is not enabled".to_string(),
@@ -1002,7 +1002,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/tag-indexing-rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1158,9 +1158,9 @@ impl MetricsAPI {
         datadog::Error<CreateTagIndexingRuleExemptionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_tag_indexing_rule_exemption";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_tag_indexing_rule_exemption";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_tag_indexing_rule_exemption' is not enabled".to_string(),
@@ -1172,7 +1172,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tag-indexing-rule-exemptions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -1335,13 +1335,13 @@ impl MetricsAPI {
         datadog::Error<DeleteBulkTagsMetricsConfigurationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_bulk_tags_metrics_configuration";
+        let local_operation_id = "v2.delete_bulk_tags_metrics_configuration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/config/bulk-tags",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1483,13 +1483,13 @@ impl MetricsAPI {
         metric_name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTagConfigurationError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_tag_configuration";
+        let local_operation_id = "v2.delete_tag_configuration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tags",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -1575,9 +1575,9 @@ impl MetricsAPI {
         id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTagIndexingRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_tag_indexing_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_tag_indexing_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_tag_indexing_rule' is not enabled".to_string(),
@@ -1589,7 +1589,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/tag-indexing-rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1679,9 +1679,9 @@ impl MetricsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTagIndexingRuleExemptionError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_tag_indexing_rule_exemption";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_tag_indexing_rule_exemption";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_tag_indexing_rule_exemption' is not enabled".to_string(),
@@ -1693,7 +1693,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tag-indexing-rule-exemptions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -1794,7 +1794,7 @@ impl MetricsAPI {
         datadog::Error<EstimateMetricsOutputSeriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.estimate_metrics_output_series";
+        let local_operation_id = "v2.estimate_metrics_output_series";
 
         // unbox and build optional parameters
         let filter_groups = params.filter_groups;
@@ -1807,7 +1807,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/estimate",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -1934,13 +1934,13 @@ impl MetricsAPI {
         datadog::Error<GetMetricTagCardinalityDetailsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_metric_tag_cardinality_details";
+        let local_operation_id = "v2.get_metric_tag_cardinality_details";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tag-cardinalities",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -2043,9 +2043,9 @@ impl MetricsAPI {
         datadog::Error<GetTagIndexingRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tag_indexing_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_tag_indexing_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_tag_indexing_rule' is not enabled".to_string(),
@@ -2057,7 +2057,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/tag-indexing-rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -2169,9 +2169,9 @@ impl MetricsAPI {
         datadog::Error<GetTagIndexingRuleExemptionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tag_indexing_rule_exemption";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_tag_indexing_rule_exemption";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_tag_indexing_rule_exemption' is not enabled".to_string(),
@@ -2183,7 +2183,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tag-indexing-rule-exemptions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -2293,7 +2293,7 @@ impl MetricsAPI {
         datadog::Error<ListActiveMetricConfigurationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_active_metric_configurations";
+        let local_operation_id = "v2.list_active_metric_configurations";
 
         // unbox and build optional parameters
         let window_seconds = params.window_seconds;
@@ -2302,7 +2302,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/active-configurations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -2409,13 +2409,13 @@ impl MetricsAPI {
         datadog::Error<ListMetricAssetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_metric_assets";
+        let local_operation_id = "v2.list_metric_assets";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/assets",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -2521,13 +2521,13 @@ impl MetricsAPI {
         datadog::Error<ListTagConfigurationByNameError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tag_configuration_by_name";
+        let local_operation_id = "v2.list_tag_configuration_by_name";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tags",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -2673,7 +2673,7 @@ impl MetricsAPI {
         datadog::Error<ListTagConfigurationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tag_configurations";
+        let local_operation_id = "v2.list_tag_configurations";
 
         // unbox and build optional parameters
         let filter_configured = params.filter_configured;
@@ -2695,7 +2695,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2859,9 +2859,9 @@ impl MetricsAPI {
         datadog::Error<ListTagIndexingRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tag_indexing_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_tag_indexing_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_tag_indexing_rules' is not enabled".to_string(),
@@ -2878,7 +2878,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/tag-indexing-rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2998,9 +2998,9 @@ impl MetricsAPI {
         datadog::Error<ListTagIndexingRulesForMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tag_indexing_rules_for_metric";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_tag_indexing_rules_for_metric";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_tag_indexing_rules_for_metric' is not enabled".to_string(),
@@ -3012,7 +3012,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tag-indexing-rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -3122,7 +3122,7 @@ impl MetricsAPI {
         datadog::Error<ListTagsByMetricNameError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tags_by_metric_name";
+        let local_operation_id = "v2.list_tags_by_metric_name";
 
         // unbox and build optional parameters
         let window_seconds = params.window_seconds;
@@ -3136,7 +3136,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/all-tags",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -3273,7 +3273,7 @@ impl MetricsAPI {
         datadog::Error<ListVolumesByMetricNameError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_volumes_by_metric_name";
+        let local_operation_id = "v2.list_volumes_by_metric_name";
 
         // unbox and build optional parameters
         let window_seconds = params.window_seconds;
@@ -3282,7 +3282,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/volumes",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -3394,13 +3394,13 @@ impl MetricsAPI {
         datadog::Error<QueryScalarDataError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_scalar_data";
+        let local_operation_id = "v2.query_scalar_data";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/query/scalar",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3551,13 +3551,13 @@ impl MetricsAPI {
         datadog::Error<QueryTimeseriesDataError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_timeseries_data";
+        let local_operation_id = "v2.query_timeseries_data";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/query/timeseries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3698,9 +3698,9 @@ impl MetricsAPI {
         body: crate::datadogV2::model::TagIndexingRuleOrderRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ReorderTagIndexingRulesError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_tag_indexing_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.reorder_tag_indexing_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.reorder_tag_indexing_rules' is not enabled".to_string(),
@@ -3712,7 +3712,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/tag-indexing-rules/order",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -3876,7 +3876,7 @@ impl MetricsAPI {
         datadog::Error<SubmitMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.submit_metrics";
+        let local_operation_id = "v2.submit_metrics";
 
         // unbox and build optional parameters
         let content_encoding = params.content_encoding;
@@ -3885,7 +3885,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/series",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4050,13 +4050,13 @@ impl MetricsAPI {
         datadog::Error<UpdateTagConfigurationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_tag_configuration";
+        let local_operation_id = "v2.update_tag_configuration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/{metric_name}/tags",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_name = datadog::urlencode(metric_name)
         );
         let mut local_req_builder =
@@ -4212,9 +4212,9 @@ impl MetricsAPI {
         datadog::Error<UpdateTagIndexingRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_tag_indexing_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_tag_indexing_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_tag_indexing_rule' is not enabled".to_string(),
@@ -4226,7 +4226,7 @@ impl MetricsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/metrics/tag-indexing-rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_microsoft_teams_integration.rs
+++ b/src/datadogV2/api/api_microsoft_teams_integration.rs
@@ -251,13 +251,13 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<CreateTenantBasedHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_tenant_based_handle";
+        let local_operation_id = "v2.create_tenant_based_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/tenant-based-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -412,13 +412,13 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<CreateWorkflowsWebhookHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_workflows_webhook_handle";
+        let local_operation_id = "v2.create_workflows_webhook_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/workflows-webhook-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -557,13 +557,13 @@ impl MicrosoftTeamsIntegrationAPI {
         tenant_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteMSTeamsUserBindingError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_ms_teams_user_binding";
+        let local_operation_id = "v2.delete_ms_teams_user_binding";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/user-binding/{tenant_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tenant_id = datadog::urlencode(tenant_id)
         );
         let mut local_req_builder =
@@ -648,13 +648,13 @@ impl MicrosoftTeamsIntegrationAPI {
         handle_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTenantBasedHandleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_tenant_based_handle";
+        let local_operation_id = "v2.delete_tenant_based_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/tenant-based-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle_id = datadog::urlencode(handle_id)
         );
         let mut local_req_builder =
@@ -740,13 +740,13 @@ impl MicrosoftTeamsIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteWorkflowsWebhookHandleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_workflows_webhook_handle";
+        let local_operation_id = "v2.delete_workflows_webhook_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/workflows-webhook-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle_id = datadog::urlencode(handle_id)
         );
         let mut local_req_builder =
@@ -849,13 +849,13 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<GetChannelByNameError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_channel_by_name";
+        let local_operation_id = "v2.get_channel_by_name";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/channel/{tenant_name}/{team_name}/{channel_name}",
-            local_configuration.get_operation_host(operation_id), tenant_name=
+            local_configuration.get_operation_host(local_operation_id), tenant_name=
             datadog::urlencode(tenant_name)
             , team_name=
             datadog::urlencode(team_name)
@@ -963,13 +963,13 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<GetTenantBasedHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tenant_based_handle";
+        let local_operation_id = "v2.get_tenant_based_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/tenant-based-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle_id = datadog::urlencode(handle_id)
         );
         let mut local_req_builder =
@@ -1078,13 +1078,13 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<GetWorkflowsWebhookHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_workflows_webhook_handle";
+        let local_operation_id = "v2.get_workflows_webhook_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/workflows-webhook-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle_id = datadog::urlencode(handle_id)
         );
         let mut local_req_builder =
@@ -1188,7 +1188,7 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<ListTenantBasedHandlesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tenant_based_handles";
+        let local_operation_id = "v2.list_tenant_based_handles";
 
         // unbox and build optional parameters
         let tenant_id = params.tenant_id;
@@ -1198,7 +1198,7 @@ impl MicrosoftTeamsIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/tenant-based-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1315,7 +1315,7 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<ListWorkflowsWebhookHandlesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_workflows_webhook_handles";
+        let local_operation_id = "v2.list_workflows_webhook_handles";
 
         // unbox and build optional parameters
         let name = params.name;
@@ -1324,7 +1324,7 @@ impl MicrosoftTeamsIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/workflows-webhook-handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1437,13 +1437,13 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<UpdateTenantBasedHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_tenant_based_handle";
+        let local_operation_id = "v2.update_tenant_based_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/tenant-based-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle_id = datadog::urlencode(handle_id)
         );
         let mut local_req_builder =
@@ -1601,13 +1601,13 @@ impl MicrosoftTeamsIntegrationAPI {
         datadog::Error<UpdateWorkflowsWebhookHandleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_workflows_webhook_handle";
+        let local_operation_id = "v2.update_workflows_webhook_handle";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/ms-teams/configuration/workflows-webhook-handles/{handle_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle_id = datadog::urlencode(handle_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_model_lab_api.rs
+++ b/src/datadogV2/api/api_model_lab_api.rs
@@ -415,9 +415,9 @@ impl ModelLabAPIAPI {
         run_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteModelLabRunError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_model_lab_run";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_model_lab_run";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_model_lab_run' is not enabled".to_string(),
@@ -429,7 +429,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/runs/{run_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             run_id = run_id
         );
         let mut local_req_builder =
@@ -525,9 +525,9 @@ impl ModelLabAPIAPI {
     ) -> Result<datadog::ResponseContent<Vec<u8>>, datadog::Error<GetModelLabArtifactContentError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_model_lab_artifact_content";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_model_lab_artifact_content";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_model_lab_artifact_content' is not enabled".to_string(),
@@ -539,7 +539,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/artifacts/content",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -638,9 +638,9 @@ impl ModelLabAPIAPI {
         datadog::Error<GetModelLabProjectError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_model_lab_project";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_model_lab_project";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_model_lab_project' is not enabled".to_string(),
@@ -652,7 +652,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/projects/{project_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = project_id
         );
         let mut local_req_builder =
@@ -753,9 +753,9 @@ impl ModelLabAPIAPI {
         datadog::Error<GetModelLabRunError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_model_lab_run";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_model_lab_run";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_model_lab_run' is not enabled".to_string(),
@@ -767,7 +767,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/runs/{run_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             run_id = run_id
         );
         let mut local_req_builder =
@@ -873,9 +873,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabProjectArtifactsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_project_artifacts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_project_artifacts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_project_artifacts' is not enabled".to_string(),
@@ -887,7 +887,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/projects/{project_id}/artifacts",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = project_id
         );
         let mut local_req_builder =
@@ -991,9 +991,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabProjectFacetKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_project_facet_keys";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_project_facet_keys";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_project_facet_keys' is not enabled".to_string(),
@@ -1005,7 +1005,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/project-facet-keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1112,9 +1112,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabProjectFacetValuesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_project_facet_values";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_project_facet_values";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_project_facet_values' is not enabled"
@@ -1127,7 +1127,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/project-facet-values",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1232,9 +1232,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabProjectsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_projects";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_projects";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_projects' is not enabled".to_string(),
@@ -1254,7 +1254,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/projects",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1386,9 +1386,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabRunArtifactsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_run_artifacts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_run_artifacts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_run_artifacts' is not enabled".to_string(),
@@ -1403,7 +1403,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/runs/{run_id}/artifacts",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             run_id = run_id
         );
         let mut local_req_builder =
@@ -1514,9 +1514,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabRunFacetKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_run_facet_keys";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_run_facet_keys";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_run_facet_keys' is not enabled".to_string(),
@@ -1528,7 +1528,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/facet-keys",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1644,9 +1644,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabRunFacetValuesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_run_facet_values";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_run_facet_values";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_run_facet_values' is not enabled".to_string(),
@@ -1658,7 +1658,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/facet-values",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1763,9 +1763,9 @@ impl ModelLabAPIAPI {
         datadog::Error<ListModelLabRunsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_model_lab_runs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_model_lab_runs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_model_lab_runs' is not enabled".to_string(),
@@ -1793,7 +1793,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/runs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1938,9 +1938,9 @@ impl ModelLabAPIAPI {
         run_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<PinModelLabRunError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.pin_model_lab_run";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.pin_model_lab_run";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.pin_model_lab_run' is not enabled".to_string(),
@@ -1952,7 +1952,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/runs/{run_id}/pin",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             run_id = run_id
         );
         let mut local_req_builder =
@@ -2034,9 +2034,9 @@ impl ModelLabAPIAPI {
         project_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<StarModelLabProjectError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.star_model_lab_project";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.star_model_lab_project";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.star_model_lab_project' is not enabled".to_string(),
@@ -2048,7 +2048,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/projects/{project_id}/star",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = project_id
         );
         let mut local_req_builder =
@@ -2130,9 +2130,9 @@ impl ModelLabAPIAPI {
         run_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnpinModelLabRunError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unpin_model_lab_run";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.unpin_model_lab_run";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.unpin_model_lab_run' is not enabled".to_string(),
@@ -2144,7 +2144,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/runs/{run_id}/pin",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             run_id = run_id
         );
         let mut local_req_builder =
@@ -2229,9 +2229,9 @@ impl ModelLabAPIAPI {
         project_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnstarModelLabProjectError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unstar_model_lab_project";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.unstar_model_lab_project";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.unstar_model_lab_project' is not enabled".to_string(),
@@ -2243,7 +2243,7 @@ impl ModelLabAPIAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/model-lab-api/projects/{project_id}/star",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             project_id = project_id
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_monitors.rs
+++ b/src/datadogV2/api/api_monitors.rs
@@ -342,13 +342,13 @@ impl MonitorsAPI {
         datadog::Error<CreateMonitorConfigPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_monitor_config_policy";
+        let local_operation_id = "v2.create_monitor_config_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/policy",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -500,13 +500,13 @@ impl MonitorsAPI {
         datadog::Error<CreateMonitorNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_monitor_notification_rule";
+        let local_operation_id = "v2.create_monitor_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/notification_rule",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -655,9 +655,9 @@ impl MonitorsAPI {
         datadog::Error<CreateMonitorUserTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_monitor_user_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_monitor_user_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_monitor_user_template' is not enabled".to_string(),
@@ -669,7 +669,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/template",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -807,13 +807,13 @@ impl MonitorsAPI {
         policy_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteMonitorConfigPolicyError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_monitor_config_policy";
+        let local_operation_id = "v2.delete_monitor_config_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/policy/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -899,13 +899,13 @@ impl MonitorsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteMonitorNotificationRuleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_monitor_notification_rule";
+        let local_operation_id = "v2.delete_monitor_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/notification_rule/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -990,9 +990,9 @@ impl MonitorsAPI {
         template_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteMonitorUserTemplateError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_monitor_user_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_monitor_user_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_monitor_user_template' is not enabled".to_string(),
@@ -1004,7 +1004,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/template/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id)
         );
         let mut local_req_builder =
@@ -1103,13 +1103,13 @@ impl MonitorsAPI {
         datadog::Error<GetMonitorConfigPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_monitor_config_policy";
+        let local_operation_id = "v2.get_monitor_config_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/policy/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -1217,7 +1217,7 @@ impl MonitorsAPI {
         datadog::Error<GetMonitorNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_monitor_notification_rule";
+        let local_operation_id = "v2.get_monitor_notification_rule";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1226,7 +1226,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/notification_rule/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -1337,7 +1337,7 @@ impl MonitorsAPI {
         datadog::Error<GetMonitorNotificationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_monitor_notification_rules";
+        let local_operation_id = "v2.get_monitor_notification_rules";
 
         // unbox and build optional parameters
         let page = params.page;
@@ -1350,7 +1350,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/notification_rule",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1478,9 +1478,9 @@ impl MonitorsAPI {
         datadog::Error<GetMonitorUserTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_monitor_user_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_monitor_user_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_monitor_user_template' is not enabled".to_string(),
@@ -1495,7 +1495,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/template/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id)
         );
         let mut local_req_builder =
@@ -1601,13 +1601,13 @@ impl MonitorsAPI {
         datadog::Error<ListMonitorConfigPoliciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_monitor_config_policies";
+        let local_operation_id = "v2.list_monitor_config_policies";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/policy",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1707,9 +1707,9 @@ impl MonitorsAPI {
         datadog::Error<ListMonitorUserTemplatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_monitor_user_templates";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_monitor_user_templates";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_monitor_user_templates' is not enabled".to_string(),
@@ -1721,7 +1721,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/template",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1828,13 +1828,13 @@ impl MonitorsAPI {
         datadog::Error<UpdateMonitorConfigPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_monitor_config_policy";
+        let local_operation_id = "v2.update_monitor_config_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/policy/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -1989,13 +1989,13 @@ impl MonitorsAPI {
         datadog::Error<UpdateMonitorNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_monitor_notification_rule";
+        let local_operation_id = "v2.update_monitor_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/notification_rule/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -2150,9 +2150,9 @@ impl MonitorsAPI {
         datadog::Error<UpdateMonitorUserTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_monitor_user_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_monitor_user_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_monitor_user_template' is not enabled".to_string(),
@@ -2164,7 +2164,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/template/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id)
         );
         let mut local_req_builder =
@@ -2308,9 +2308,9 @@ impl MonitorsAPI {
         datadog::Error<ValidateExistingMonitorUserTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_existing_monitor_user_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.validate_existing_monitor_user_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.validate_existing_monitor_user_template' is not enabled"
@@ -2323,7 +2323,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/template/{template_id}/validate",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id)
         );
         let mut local_req_builder =
@@ -2456,9 +2456,9 @@ impl MonitorsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ValidateMonitorUserTemplateError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_monitor_user_template";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.validate_monitor_user_template";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.validate_monitor_user_template' is not enabled".to_string(),
@@ -2470,7 +2470,7 @@ impl MonitorsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/monitor/template/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_network_device_monitoring.rs
+++ b/src/datadogV2/api/api_network_device_monitoring.rs
@@ -223,13 +223,13 @@ impl NetworkDeviceMonitoringAPI {
         datadog::Error<GetDeviceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_device";
+        let local_operation_id = "v2.get_device";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ndm/devices/{device_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             device_id = datadog::urlencode(device_id)
         );
         let mut local_req_builder =
@@ -330,7 +330,7 @@ impl NetworkDeviceMonitoringAPI {
         datadog::Error<GetInterfacesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_interfaces";
+        let local_operation_id = "v2.get_interfaces";
 
         // unbox and build optional parameters
         let get_ip_addresses = params.get_ip_addresses;
@@ -339,7 +339,7 @@ impl NetworkDeviceMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ndm/interfaces",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -445,13 +445,13 @@ impl NetworkDeviceMonitoringAPI {
         datadog::Error<ListDeviceUserTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_device_user_tags";
+        let local_operation_id = "v2.list_device_user_tags";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ndm/tags/devices/{device_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             device_id = datadog::urlencode(device_id)
         );
         let mut local_req_builder =
@@ -584,7 +584,7 @@ impl NetworkDeviceMonitoringAPI {
         datadog::Error<ListDevicesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_devices";
+        let local_operation_id = "v2.list_devices";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -596,7 +596,7 @@ impl NetworkDeviceMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/ndm/devices",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -717,13 +717,13 @@ impl NetworkDeviceMonitoringAPI {
         datadog::Error<ListInterfaceUserTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_interface_user_tags";
+        let local_operation_id = "v2.list_interface_user_tags";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ndm/tags/interfaces/{interface_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             interface_id = datadog::urlencode(interface_id)
         );
         let mut local_req_builder =
@@ -829,13 +829,13 @@ impl NetworkDeviceMonitoringAPI {
         datadog::Error<UpdateDeviceUserTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_device_user_tags";
+        let local_operation_id = "v2.update_device_user_tags";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ndm/tags/devices/{device_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             device_id = datadog::urlencode(device_id)
         );
         let mut local_req_builder =
@@ -989,13 +989,13 @@ impl NetworkDeviceMonitoringAPI {
         datadog::Error<UpdateInterfaceUserTagsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_interface_user_tags";
+        let local_operation_id = "v2.update_interface_user_tags";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ndm/tags/interfaces/{interface_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             interface_id = datadog::urlencode(interface_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_network_health_insights.rs
+++ b/src/datadogV2/api/api_network_health_insights.rs
@@ -164,9 +164,9 @@ impl NetworkHealthInsightsAPI {
         datadog::Error<ListNetworkHealthInsightsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_network_health_insights";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_network_health_insights";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_network_health_insights' is not enabled".to_string(),
@@ -182,7 +182,7 @@ impl NetworkHealthInsightsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/network-health-insights",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_o_auth2_client_public.rs
+++ b/src/datadogV2/api/api_o_auth2_client_public.rs
@@ -150,9 +150,9 @@ impl OAuth2ClientPublicAPI {
         client_uuid: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteScopesRestrictionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_scopes_restriction";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_scopes_restriction";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_scopes_restriction' is not enabled".to_string(),
@@ -164,7 +164,7 @@ impl OAuth2ClientPublicAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/oauth2/clients/{client_uuid}/scopes_restriction",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             client_uuid = datadog::urlencode(client_uuid.to_string())
         );
         let mut local_req_builder =
@@ -258,9 +258,9 @@ impl OAuth2ClientPublicAPI {
         datadog::Error<GetOAuth2WellKnownSitesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_o_auth2_well_known_sites";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_o_auth2_well_known_sites";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_o_auth2_well_known_sites' is not enabled".to_string(),
@@ -272,7 +272,7 @@ impl OAuth2ClientPublicAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/oauth2/.well-known/sites",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -363,9 +363,9 @@ impl OAuth2ClientPublicAPI {
         datadog::Error<GetScopesRestrictionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_scopes_restriction";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_scopes_restriction";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_scopes_restriction' is not enabled".to_string(),
@@ -377,7 +377,7 @@ impl OAuth2ClientPublicAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/oauth2/clients/{client_uuid}/scopes_restriction",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             client_uuid = datadog::urlencode(client_uuid.to_string())
         );
         let mut local_req_builder =
@@ -480,9 +480,9 @@ impl OAuth2ClientPublicAPI {
         datadog::Error<RegisterOAuthClientError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.register_o_auth_client";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.register_o_auth_client";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.register_o_auth_client' is not enabled".to_string(),
@@ -494,7 +494,7 @@ impl OAuth2ClientPublicAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/oauth2/register",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -634,9 +634,9 @@ impl OAuth2ClientPublicAPI {
         datadog::Error<UpsertScopesRestrictionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_scopes_restriction";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.upsert_scopes_restriction";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.upsert_scopes_restriction' is not enabled".to_string(),
@@ -648,7 +648,7 @@ impl OAuth2ClientPublicAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/oauth2/clients/{client_uuid}/scopes_restriction",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             client_uuid = datadog::urlencode(client_uuid.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_observability_pipelines.rs
+++ b/src/datadogV2/api/api_observability_pipelines.rs
@@ -184,13 +184,13 @@ impl ObservabilityPipelinesAPI {
         datadog::Error<CreatePipelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_pipeline";
+        let local_operation_id = "v2.create_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/obs-pipelines/pipelines",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -325,13 +325,13 @@ impl ObservabilityPipelinesAPI {
         pipeline_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeletePipelineError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_pipeline";
+        let local_operation_id = "v2.delete_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/obs-pipelines/pipelines/{pipeline_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             pipeline_id = datadog::urlencode(pipeline_id)
         );
         let mut local_req_builder =
@@ -425,13 +425,13 @@ impl ObservabilityPipelinesAPI {
         datadog::Error<GetPipelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_pipeline";
+        let local_operation_id = "v2.get_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/obs-pipelines/pipelines/{pipeline_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             pipeline_id = datadog::urlencode(pipeline_id)
         );
         let mut local_req_builder =
@@ -531,7 +531,7 @@ impl ObservabilityPipelinesAPI {
         datadog::Error<ListPipelinesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_pipelines";
+        let local_operation_id = "v2.list_pipelines";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -541,7 +541,7 @@ impl ObservabilityPipelinesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/obs-pipelines/pipelines",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -652,13 +652,13 @@ impl ObservabilityPipelinesAPI {
         datadog::Error<UpdatePipelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_pipeline";
+        let local_operation_id = "v2.update_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/obs-pipelines/pipelines/{pipeline_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             pipeline_id = datadog::urlencode(pipeline_id)
         );
         let mut local_req_builder =
@@ -808,13 +808,13 @@ impl ObservabilityPipelinesAPI {
         datadog::Error<ValidatePipelineError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_pipeline";
+        let local_operation_id = "v2.validate_pipeline";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/obs-pipelines/pipelines/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_oci_integration.rs
+++ b/src/datadogV2/api/api_oci_integration.rs
@@ -162,9 +162,9 @@ impl OCIIntegrationAPI {
         datadog::Error<CreateTenancyConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_tenancy_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_tenancy_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_tenancy_config' is not enabled".to_string(),
@@ -176,7 +176,7 @@ impl OCIIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/oci/tenancies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -312,13 +312,13 @@ impl OCIIntegrationAPI {
         tenancy_ocid: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTenancyConfigError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_tenancy_config";
+        let local_operation_id = "v2.delete_tenancy_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/oci/tenancies/{tenancy_ocid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tenancy_ocid = datadog::urlencode(tenancy_ocid)
         );
         let mut local_req_builder =
@@ -411,13 +411,13 @@ impl OCIIntegrationAPI {
         datadog::Error<GetTenancyConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tenancy_config";
+        let local_operation_id = "v2.get_tenancy_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/oci/tenancies/{tenancy_ocid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tenancy_ocid = datadog::urlencode(tenancy_ocid)
         );
         let mut local_req_builder =
@@ -514,9 +514,9 @@ impl OCIIntegrationAPI {
         datadog::Error<GetTenancyConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tenancy_configs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_tenancy_configs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_tenancy_configs' is not enabled".to_string(),
@@ -528,7 +528,7 @@ impl OCIIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/oci/tenancies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -632,13 +632,13 @@ impl OCIIntegrationAPI {
         datadog::Error<ListTenancyProductsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tenancy_products";
+        let local_operation_id = "v2.list_tenancy_products";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/oci/products",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -745,13 +745,13 @@ impl OCIIntegrationAPI {
         datadog::Error<UpdateTenancyConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_tenancy_config";
+        let local_operation_id = "v2.update_tenancy_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/oci/tenancies/{tenancy_ocid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             tenancy_ocid = datadog::urlencode(tenancy_ocid)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_okta_integration.rs
+++ b/src/datadogV2/api/api_okta_integration.rs
@@ -153,13 +153,13 @@ impl OktaIntegrationAPI {
         datadog::Error<CreateOktaAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_okta_account";
+        let local_operation_id = "v2.create_okta_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/okta/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -294,13 +294,13 @@ impl OktaIntegrationAPI {
         account_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOktaAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_okta_account";
+        let local_operation_id = "v2.delete_okta_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/okta/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -394,13 +394,13 @@ impl OktaIntegrationAPI {
         datadog::Error<GetOktaAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_okta_account";
+        let local_operation_id = "v2.get_okta_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/okta/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -499,13 +499,13 @@ impl OktaIntegrationAPI {
         datadog::Error<ListOktaAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_okta_accounts";
+        let local_operation_id = "v2.list_okta_accounts";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/okta/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -610,13 +610,13 @@ impl OktaIntegrationAPI {
         datadog::Error<UpdateOktaAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_okta_account";
+        let local_operation_id = "v2.update_okta_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integrations/okta/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_on_call.rs
+++ b/src/datadogV2/api/api_on_call.rs
@@ -542,7 +542,7 @@ impl OnCallAPI {
         datadog::Error<CreateOnCallEscalationPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_on_call_escalation_policy";
+        let local_operation_id = "v2.create_on_call_escalation_policy";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -551,7 +551,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/escalation-policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -706,7 +706,7 @@ impl OnCallAPI {
         datadog::Error<CreateOnCallScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_on_call_schedule";
+        let local_operation_id = "v2.create_on_call_schedule";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -715,7 +715,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/schedules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -872,13 +872,13 @@ impl OnCallAPI {
         datadog::Error<CreateUserNotificationChannelError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_user_notification_channel";
+        let local_operation_id = "v2.create_user_notification_channel";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-channels",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -1033,13 +1033,13 @@ impl OnCallAPI {
         datadog::Error<CreateUserNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_user_notification_rule";
+        let local_operation_id = "v2.create_user_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -1179,13 +1179,13 @@ impl OnCallAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOnCallEscalationPolicyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_on_call_escalation_policy";
+        let local_operation_id = "v2.delete_on_call_escalation_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/escalation-policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -1270,13 +1270,13 @@ impl OnCallAPI {
         schedule_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOnCallScheduleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_on_call_schedule";
+        let local_operation_id = "v2.delete_on_call_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/schedules/{schedule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_id = datadog::urlencode(schedule_id)
         );
         let mut local_req_builder =
@@ -1364,13 +1364,13 @@ impl OnCallAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteUserNotificationChannelError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_user_notification_channel";
+        let local_operation_id = "v2.delete_user_notification_channel";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-channels/{channel_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id),
             channel_id = datadog::urlencode(channel_id)
         );
@@ -1458,13 +1458,13 @@ impl OnCallAPI {
         rule_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteUserNotificationRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_user_notification_rule";
+        let local_operation_id = "v2.delete_user_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -1566,7 +1566,7 @@ impl OnCallAPI {
         datadog::Error<GetOnCallEscalationPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_on_call_escalation_policy";
+        let local_operation_id = "v2.get_on_call_escalation_policy";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1575,7 +1575,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/escalation-policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -1684,7 +1684,7 @@ impl OnCallAPI {
         datadog::Error<GetOnCallScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_on_call_schedule";
+        let local_operation_id = "v2.get_on_call_schedule";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1693,7 +1693,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/schedules/{schedule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_id = datadog::urlencode(schedule_id)
         );
         let mut local_req_builder =
@@ -1804,7 +1804,7 @@ impl OnCallAPI {
         datadog::Error<GetOnCallTeamRoutingRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_on_call_team_routing_rules";
+        let local_operation_id = "v2.get_on_call_team_routing_rules";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1813,7 +1813,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/teams/{team_id}/routing-rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -1925,7 +1925,7 @@ impl OnCallAPI {
         datadog::Error<GetScheduleOnCallRespondersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_schedule_on_call_responders";
+        let local_operation_id = "v2.get_schedule_on_call_responders";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1936,7 +1936,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/schedules/{schedule_id}/responders",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_id = datadog::urlencode(schedule_id)
         );
         let mut local_req_builder =
@@ -2054,7 +2054,7 @@ impl OnCallAPI {
         datadog::Error<GetScheduleOnCallUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_schedule_on_call_user";
+        let local_operation_id = "v2.get_schedule_on_call_user";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2064,7 +2064,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/schedules/{schedule_id}/on-call",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_id = datadog::urlencode(schedule_id)
         );
         let mut local_req_builder =
@@ -2179,7 +2179,7 @@ impl OnCallAPI {
         datadog::Error<GetTeamOnCallUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_on_call_users";
+        let local_operation_id = "v2.get_team_on_call_users";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2188,7 +2188,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/teams/{team_id}/on-call",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -2301,13 +2301,13 @@ impl OnCallAPI {
         datadog::Error<GetUserNotificationChannelError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_user_notification_channel";
+        let local_operation_id = "v2.get_user_notification_channel";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-channels/{channel_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id),
             channel_id = datadog::urlencode(channel_id)
         );
@@ -2418,7 +2418,7 @@ impl OnCallAPI {
         datadog::Error<GetUserNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_user_notification_rule";
+        let local_operation_id = "v2.get_user_notification_rule";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2427,7 +2427,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -2539,13 +2539,13 @@ impl OnCallAPI {
         datadog::Error<ListUserNotificationChannelsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_user_notification_channels";
+        let local_operation_id = "v2.list_user_notification_channels";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-channels",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -2653,7 +2653,7 @@ impl OnCallAPI {
         datadog::Error<ListUserNotificationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_user_notification_rules";
+        let local_operation_id = "v2.list_user_notification_rules";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2662,7 +2662,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -2777,7 +2777,7 @@ impl OnCallAPI {
         datadog::Error<SetOnCallTeamRoutingRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.set_on_call_team_routing_rules";
+        let local_operation_id = "v2.set_on_call_team_routing_rules";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2786,7 +2786,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/teams/{team_id}/routing-rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -2947,7 +2947,7 @@ impl OnCallAPI {
         datadog::Error<UpdateOnCallEscalationPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_on_call_escalation_policy";
+        let local_operation_id = "v2.update_on_call_escalation_policy";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2956,7 +2956,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/escalation-policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -3114,7 +3114,7 @@ impl OnCallAPI {
         datadog::Error<UpdateOnCallScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_on_call_schedule";
+        let local_operation_id = "v2.update_on_call_schedule";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -3123,7 +3123,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/schedules/{schedule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_id = datadog::urlencode(schedule_id)
         );
         let mut local_req_builder =
@@ -3285,7 +3285,7 @@ impl OnCallAPI {
         datadog::Error<UpdateUserNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_user_notification_rule";
+        let local_operation_id = "v2.update_user_notification_rule";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -3294,7 +3294,7 @@ impl OnCallAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/users/{user_id}/notification-rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id),
             rule_id = datadog::urlencode(rule_id)
         );

--- a/src/datadogV2/api/api_on_call_paging.rs
+++ b/src/datadogV2/api/api_on_call_paging.rs
@@ -134,13 +134,13 @@ impl OnCallPagingAPI {
         page_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<AcknowledgeOnCallPageError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.acknowledge_on_call_page";
+        let local_operation_id = "v2.acknowledge_on_call_page";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/pages/{page_id}/acknowledge",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -234,13 +234,13 @@ impl OnCallPagingAPI {
         datadog::Error<CreateOnCallPageError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_on_call_page";
+        let local_operation_id = "v2.create_on_call_page";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/pages",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -375,13 +375,13 @@ impl OnCallPagingAPI {
         page_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<EscalateOnCallPageError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.escalate_on_call_page";
+        let local_operation_id = "v2.escalate_on_call_page";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/pages/{page_id}/escalate",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -463,13 +463,13 @@ impl OnCallPagingAPI {
         page_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ResolveOnCallPageError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.resolve_on_call_page";
+        let local_operation_id = "v2.resolve_on_call_page";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/on-call/pages/{page_id}/resolve",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_opsgenie_integration.rs
+++ b/src/datadogV2/api/api_opsgenie_integration.rs
@@ -189,13 +189,13 @@ impl OpsgenieIntegrationAPI {
         datadog::Error<CreateOpsgenieAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_opsgenie_account";
+        let local_operation_id = "v2.create_opsgenie_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -344,13 +344,13 @@ impl OpsgenieIntegrationAPI {
         datadog::Error<CreateOpsgenieServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_opsgenie_service";
+        let local_operation_id = "v2.create_opsgenie_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/services",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -488,13 +488,13 @@ impl OpsgenieIntegrationAPI {
         account_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOpsgenieAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_opsgenie_account";
+        let local_operation_id = "v2.delete_opsgenie_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -579,13 +579,13 @@ impl OpsgenieIntegrationAPI {
         integration_service_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOpsgenieServiceError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_opsgenie_service";
+        let local_operation_id = "v2.delete_opsgenie_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/services/{integration_service_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_service_id = datadog::urlencode(integration_service_id)
         );
         let mut local_req_builder =
@@ -684,13 +684,13 @@ impl OpsgenieIntegrationAPI {
         datadog::Error<GetOpsgenieServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_opsgenie_service";
+        let local_operation_id = "v2.get_opsgenie_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/services/{integration_service_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_service_id = datadog::urlencode(integration_service_id)
         );
         let mut local_req_builder =
@@ -791,13 +791,13 @@ impl OpsgenieIntegrationAPI {
         datadog::Error<ListOpsgenieAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_opsgenie_accounts";
+        let local_operation_id = "v2.list_opsgenie_accounts";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -897,13 +897,13 @@ impl OpsgenieIntegrationAPI {
         datadog::Error<ListOpsgenieServicesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_opsgenie_services";
+        let local_operation_id = "v2.list_opsgenie_services";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/services",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1010,13 +1010,13 @@ impl OpsgenieIntegrationAPI {
         datadog::Error<UpdateOpsgenieAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_opsgenie_account";
+        let local_operation_id = "v2.update_opsgenie_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             account_id = datadog::urlencode(account_id)
         );
         let mut local_req_builder =
@@ -1171,13 +1171,13 @@ impl OpsgenieIntegrationAPI {
         datadog::Error<UpdateOpsgenieServiceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_opsgenie_service";
+        let local_operation_id = "v2.update_opsgenie_service";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/opsgenie/services/{integration_service_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_service_id = datadog::urlencode(integration_service_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_org_authorized_clients.rs
+++ b/src/datadogV2/api/api_org_authorized_clients.rs
@@ -322,13 +322,13 @@ impl OrgAuthorizedClientsAPI {
         org_authorized_client_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOrgAuthorizedClientError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_org_authorized_client";
+        let local_operation_id = "v2.delete_org_authorized_client";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_authorized_clients/{org_authorized_client_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_authorized_client_id = datadog::urlencode(org_authorized_client_id)
         );
         let mut local_req_builder =
@@ -421,13 +421,13 @@ impl OrgAuthorizedClientsAPI {
         datadog::Error<DeleteOrgAuthorizedClientAllUserAuthorizationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_org_authorized_client_all_user_authorizations";
+        let local_operation_id = "v2.delete_org_authorized_client_all_user_authorizations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_authorized_clients/{org_authorized_client_id}/user/{user_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_authorized_client_id = datadog::urlencode(org_authorized_client_id),
             user_id = datadog::urlencode(user_id)
         );
@@ -521,13 +521,13 @@ impl OrgAuthorizedClientsAPI {
         datadog::Error<DeleteOrgAuthorizedClientUserAuthorizationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_org_authorized_client_user_authorization";
+        let local_operation_id = "v2.delete_org_authorized_client_user_authorization";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_authorized_clients/{org_authorized_client_id}/user_authorized_clients/{user_authorized_client_id}",
-            local_configuration.get_operation_host(operation_id), org_authorized_client_id=
+            local_configuration.get_operation_host(local_operation_id), org_authorized_client_id=
             datadog::urlencode(org_authorized_client_id)
             , user_authorized_client_id=
             datadog::urlencode(user_authorized_client_id)
@@ -630,7 +630,7 @@ impl OrgAuthorizedClientsAPI {
         datadog::Error<GetOrgAuthorizedClientError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_org_authorized_client";
+        let local_operation_id = "v2.get_org_authorized_client";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -643,7 +643,7 @@ impl OrgAuthorizedClientsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_authorized_clients/{org_authorized_client_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_authorized_client_id = datadog::urlencode(org_authorized_client_id)
         );
         let mut local_req_builder =
@@ -807,7 +807,7 @@ impl OrgAuthorizedClientsAPI {
         datadog::Error<ListOrgAuthorizedClientUserAuthorizationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_authorized_client_user_authorizations";
+        let local_operation_id = "v2.list_org_authorized_client_user_authorizations";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -822,7 +822,7 @@ impl OrgAuthorizedClientsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_authorized_clients/{org_authorized_client_id}/user_authorized_clients",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_authorized_client_id = datadog::urlencode(org_authorized_client_id)
         );
         let mut local_req_builder =
@@ -992,7 +992,7 @@ impl OrgAuthorizedClientsAPI {
         datadog::Error<ListOrgAuthorizedClientsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_authorized_clients";
+        let local_operation_id = "v2.list_org_authorized_clients";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1007,7 +1007,7 @@ impl OrgAuthorizedClientsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_authorized_clients",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1145,13 +1145,13 @@ impl OrgAuthorizedClientsAPI {
         datadog::Error<UpdateOrgAuthorizedClientError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_authorized_client";
+        let local_operation_id = "v2.update_org_authorized_client";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_authorized_clients/{org_authorized_client_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_authorized_client_id = datadog::urlencode(org_authorized_client_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_org_connections.rs
+++ b/src/datadogV2/api/api_org_connections.rs
@@ -184,13 +184,13 @@ impl OrgConnectionsAPI {
         datadog::Error<CreateOrgConnectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_org_connections";
+        let local_operation_id = "v2.create_org_connections";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_connections",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -328,13 +328,13 @@ impl OrgConnectionsAPI {
         connection_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOrgConnectionsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_org_connections";
+        let local_operation_id = "v2.delete_org_connections";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_connections/{connection_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             connection_id = datadog::urlencode(connection_id.to_string())
         );
         let mut local_req_builder =
@@ -430,7 +430,7 @@ impl OrgConnectionsAPI {
         datadog::Error<ListOrgConnectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_connections";
+        let local_operation_id = "v2.list_org_connections";
 
         // unbox and build optional parameters
         let sink_org_id = params.sink_org_id;
@@ -442,7 +442,7 @@ impl OrgConnectionsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_connections",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -566,13 +566,13 @@ impl OrgConnectionsAPI {
         datadog::Error<UpdateOrgConnectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_connections";
+        let local_operation_id = "v2.update_org_connections";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_connections/{connection_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             connection_id = datadog::urlencode(connection_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_org_groups.rs
+++ b/src/datadogV2/api/api_org_groups.rs
@@ -459,9 +459,9 @@ impl OrgGroupsAPI {
         datadog::Error<BulkUpdateOrgGroupMembershipsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_update_org_group_memberships";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.bulk_update_org_group_memberships";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.bulk_update_org_group_memberships' is not enabled".to_string(),
@@ -473,7 +473,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_memberships/bulk",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -620,9 +620,9 @@ impl OrgGroupsAPI {
         datadog::Error<CreateOrgGroupError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_org_group";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_org_group";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_org_group' is not enabled".to_string(),
@@ -634,7 +634,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_groups",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -782,9 +782,9 @@ impl OrgGroupsAPI {
         datadog::Error<CreateOrgGroupPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_org_group_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_org_group_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_org_group_policy' is not enabled".to_string(),
@@ -796,7 +796,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -948,9 +948,9 @@ impl OrgGroupsAPI {
         datadog::Error<CreateOrgGroupPolicyOverrideError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_org_group_policy_override";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_org_group_policy_override";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_org_group_policy_override' is not enabled".to_string(),
@@ -962,7 +962,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policy_overrides",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1097,9 +1097,9 @@ impl OrgGroupsAPI {
         org_group_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOrgGroupError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_org_group";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_org_group";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_org_group' is not enabled".to_string(),
@@ -1111,7 +1111,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_groups/{org_group_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_id = datadog::urlencode(org_group_id.to_string())
         );
         let mut local_req_builder =
@@ -1196,9 +1196,9 @@ impl OrgGroupsAPI {
         org_group_policy_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOrgGroupPolicyError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_org_group_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_org_group_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_org_group_policy' is not enabled".to_string(),
@@ -1210,7 +1210,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policies/{org_group_policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_policy_id = datadog::urlencode(org_group_policy_id.to_string())
         );
         let mut local_req_builder =
@@ -1296,9 +1296,9 @@ impl OrgGroupsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOrgGroupPolicyOverrideError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_org_group_policy_override";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_org_group_policy_override";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_org_group_policy_override' is not enabled".to_string(),
@@ -1310,7 +1310,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policy_overrides/{org_group_policy_override_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_policy_override_id =
                 datadog::urlencode(org_group_policy_override_id.to_string())
         );
@@ -1404,9 +1404,9 @@ impl OrgGroupsAPI {
         datadog::Error<GetOrgGroupError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_org_group";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_org_group";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_org_group' is not enabled".to_string(),
@@ -1418,7 +1418,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_groups/{org_group_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_id = datadog::urlencode(org_group_id.to_string())
         );
         let mut local_req_builder =
@@ -1522,9 +1522,9 @@ impl OrgGroupsAPI {
         datadog::Error<GetOrgGroupMembershipError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_org_group_membership";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_org_group_membership";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_org_group_membership' is not enabled".to_string(),
@@ -1536,7 +1536,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_memberships/{org_group_membership_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_membership_id = datadog::urlencode(org_group_membership_id.to_string())
         );
         let mut local_req_builder =
@@ -1642,9 +1642,9 @@ impl OrgGroupsAPI {
         datadog::Error<GetOrgGroupPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_org_group_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_org_group_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_org_group_policy' is not enabled".to_string(),
@@ -1656,7 +1656,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policies/{org_group_policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_policy_id = datadog::urlencode(org_group_policy_id.to_string())
         );
         let mut local_req_builder =
@@ -1762,9 +1762,9 @@ impl OrgGroupsAPI {
         datadog::Error<GetOrgGroupPolicyOverrideError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_org_group_policy_override";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_org_group_policy_override";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_org_group_policy_override' is not enabled".to_string(),
@@ -1776,7 +1776,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policy_overrides/{org_group_policy_override_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_policy_override_id =
                 datadog::urlencode(org_group_policy_override_id.to_string())
         );
@@ -1880,9 +1880,9 @@ impl OrgGroupsAPI {
         datadog::Error<ListOrgGroupMembershipsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_group_memberships";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_org_group_memberships";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_org_group_memberships' is not enabled".to_string(),
@@ -1901,7 +1901,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_memberships",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2029,9 +2029,9 @@ impl OrgGroupsAPI {
         datadog::Error<ListOrgGroupPoliciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_group_policies";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_org_group_policies";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_org_group_policies' is not enabled".to_string(),
@@ -2049,7 +2049,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2168,9 +2168,9 @@ impl OrgGroupsAPI {
         datadog::Error<ListOrgGroupPolicyConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_group_policy_configs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_org_group_policy_configs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_org_group_policy_configs' is not enabled".to_string(),
@@ -2182,7 +2182,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policy_configs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2289,9 +2289,9 @@ impl OrgGroupsAPI {
         datadog::Error<ListOrgGroupPolicyOverridesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_group_policy_overrides";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_org_group_policy_overrides";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_org_group_policy_overrides' is not enabled".to_string(),
@@ -2309,7 +2309,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policy_overrides",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2433,9 +2433,9 @@ impl OrgGroupsAPI {
         datadog::Error<ListOrgGroupPolicySuggestionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_group_policy_suggestions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_org_group_policy_suggestions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_org_group_policy_suggestions' is not enabled".to_string(),
@@ -2447,7 +2447,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policy_suggestions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2551,9 +2551,9 @@ impl OrgGroupsAPI {
         datadog::Error<ListOrgGroupsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_groups";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_org_groups";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_org_groups' is not enabled".to_string(),
@@ -2570,7 +2570,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_groups",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2688,9 +2688,9 @@ impl OrgGroupsAPI {
         datadog::Error<UpdateOrgGroupError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_group";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_org_group";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_org_group' is not enabled".to_string(),
@@ -2702,7 +2702,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_groups/{org_group_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_id = datadog::urlencode(org_group_id.to_string())
         );
         let mut local_req_builder =
@@ -2856,9 +2856,9 @@ impl OrgGroupsAPI {
         datadog::Error<UpdateOrgGroupMembershipError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_group_membership";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_org_group_membership";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_org_group_membership' is not enabled".to_string(),
@@ -2870,7 +2870,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_memberships/{org_group_membership_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_membership_id = datadog::urlencode(org_group_membership_id.to_string())
         );
         let mut local_req_builder =
@@ -3025,9 +3025,9 @@ impl OrgGroupsAPI {
         datadog::Error<UpdateOrgGroupPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_group_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_org_group_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_org_group_policy' is not enabled".to_string(),
@@ -3039,7 +3039,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policies/{org_group_policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_policy_id = datadog::urlencode(org_group_policy_id.to_string())
         );
         let mut local_req_builder =
@@ -3194,9 +3194,9 @@ impl OrgGroupsAPI {
         datadog::Error<UpdateOrgGroupPolicyOverrideError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_group_policy_override";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_org_group_policy_override";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_org_group_policy_override' is not enabled".to_string(),
@@ -3208,7 +3208,7 @@ impl OrgGroupsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org_group_policy_overrides/{org_group_policy_override_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_group_policy_override_id =
                 datadog::urlencode(org_group_policy_override_id.to_string())
         );

--- a/src/datadogV2/api/api_organizations.rs
+++ b/src/datadogV2/api/api_organizations.rs
@@ -262,13 +262,13 @@ impl OrganizationsAPI {
         datadog::Error<GetOrgConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_org_config";
+        let local_operation_id = "v2.get_org_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_configs/{org_config_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_config_name = datadog::urlencode(org_config_name)
         );
         let mut local_req_builder =
@@ -373,13 +373,13 @@ impl OrganizationsAPI {
         datadog::Error<GetSAMLConfigurationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_saml_configuration";
+        let local_operation_id = "v2.get_saml_configuration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/saml_configurations/{saml_config_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             saml_config_uuid = datadog::urlencode(saml_config_uuid)
         );
         let mut local_req_builder =
@@ -519,7 +519,7 @@ impl OrganizationsAPI {
         datadog::Error<ListGlobalOrgsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_global_orgs";
+        let local_operation_id = "v2.list_global_orgs";
 
         // unbox and build optional parameters
         let page_limit = params.page_limit;
@@ -529,7 +529,7 @@ impl OrganizationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/global_orgs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -637,13 +637,13 @@ impl OrganizationsAPI {
         datadog::Error<ListOrgConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_org_configs";
+        let local_operation_id = "v2.list_org_configs";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_configs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -742,7 +742,7 @@ impl OrganizationsAPI {
         datadog::Error<ListOrgsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_orgs";
+        let local_operation_id = "v2.list_orgs";
 
         // unbox and build optional parameters
         let filter_name = params.filter_name;
@@ -751,7 +751,7 @@ impl OrganizationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -855,13 +855,13 @@ impl OrganizationsAPI {
         datadog::Error<ListSAMLConfigurationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_saml_configurations";
+        let local_operation_id = "v2.list_saml_configurations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/saml_configurations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -957,13 +957,13 @@ impl OrganizationsAPI {
         datadog::Error<UpdateLoginOrgConfigsMaxSessionDurationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_login_org_configs_max_session_duration";
+        let local_operation_id = "v2.update_login_org_configs_max_session_duration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/login/org_configs/max_session_duration",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -1108,13 +1108,13 @@ impl OrganizationsAPI {
         datadog::Error<UpdateOrgConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_config";
+        let local_operation_id = "v2.update_org_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/org_configs/{org_config_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             org_config_name = datadog::urlencode(org_config_name)
         );
         let mut local_req_builder =
@@ -1260,9 +1260,9 @@ impl OrganizationsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateOrgSamlConfigurationsError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_org_saml_configurations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_org_saml_configurations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_org_saml_configurations' is not enabled".to_string(),
@@ -1274,7 +1274,7 @@ impl OrganizationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/org/saml_configurations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -1429,13 +1429,13 @@ impl OrganizationsAPI {
         datadog::Error<UpdateSAMLConfigurationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_saml_configuration";
+        let local_operation_id = "v2.update_saml_configuration";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/saml_configurations/{saml_config_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             saml_config_uuid = datadog::urlencode(saml_config_uuid)
         );
         let mut local_req_builder =
@@ -1575,7 +1575,7 @@ impl OrganizationsAPI {
         params: UploadIdPMetadataOptionalParams,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UploadIdPMetadataError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.upload_idp_metadata";
+        let local_operation_id = "v2.upload_idp_metadata";
 
         // unbox and build optional parameters
         let idp_file = params.idp_file;
@@ -1584,7 +1584,7 @@ impl OrganizationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/saml_configurations/idp_metadata",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_powerpack.rs
+++ b/src/datadogV2/api/api_powerpack.rs
@@ -188,13 +188,13 @@ impl PowerpackAPI {
         datadog::Error<CreatePowerpackError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_powerpack";
+        let local_operation_id = "v2.create_powerpack";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/powerpacks",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -328,13 +328,13 @@ impl PowerpackAPI {
         powerpack_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeletePowerpackError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_powerpack";
+        let local_operation_id = "v2.delete_powerpack";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/powerpacks/{powerpack_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             powerpack_id = datadog::urlencode(powerpack_id)
         );
         let mut local_req_builder =
@@ -427,13 +427,13 @@ impl PowerpackAPI {
         datadog::Error<GetPowerpackError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_powerpack";
+        let local_operation_id = "v2.get_powerpack";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/powerpacks/{powerpack_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             powerpack_id = datadog::urlencode(powerpack_id)
         );
         let mut local_req_builder =
@@ -566,7 +566,7 @@ impl PowerpackAPI {
         datadog::Error<ListPowerpacksError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_powerpacks";
+        let local_operation_id = "v2.list_powerpacks";
 
         // unbox and build optional parameters
         let page_limit = params.page_limit;
@@ -576,7 +576,7 @@ impl PowerpackAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/powerpacks",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -690,13 +690,13 @@ impl PowerpackAPI {
         datadog::Error<UpdatePowerpackError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_powerpack";
+        let local_operation_id = "v2.update_powerpack";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/powerpacks/{powerpack_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             powerpack_id = datadog::urlencode(powerpack_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_processes.rs
+++ b/src/datadogV2/api/api_processes.rs
@@ -213,7 +213,7 @@ impl ProcessesAPI {
         datadog::Error<ListProcessesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_processes";
+        let local_operation_id = "v2.list_processes";
 
         // unbox and build optional parameters
         let search = params.search;
@@ -227,7 +227,7 @@ impl ProcessesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/processes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_product_analytics.rs
+++ b/src/datadogV2/api/api_product_analytics.rs
@@ -151,13 +151,13 @@ impl ProductAnalyticsAPI {
         datadog::Error<QueryProductAnalyticsScalarError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_product_analytics_scalar";
+        let local_operation_id = "v2.query_product_analytics_scalar";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/analytics/scalar",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -313,13 +313,13 @@ impl ProductAnalyticsAPI {
         datadog::Error<QueryProductAnalyticsTimeseriesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_product_analytics_timeseries";
+        let local_operation_id = "v2.query_product_analytics_timeseries";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/analytics/timeseries",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -527,13 +527,13 @@ impl ProductAnalyticsAPI {
         datadog::Error<SubmitProductAnalyticsEventError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.submit_product_analytics_event";
+        let local_operation_id = "v2.submit_product_analytics_event";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/prodlytics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_reference_tables.rs
+++ b/src/datadogV2/api/api_reference_tables.rs
@@ -275,13 +275,13 @@ impl ReferenceTablesAPI {
         datadog::Error<BatchRowsQueryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.batch_rows_query";
+        let local_operation_id = "v2.batch_rows_query";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/queries/batch-rows",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -436,13 +436,13 @@ impl ReferenceTablesAPI {
         datadog::Error<CreateReferenceTableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_reference_table";
+        let local_operation_id = "v2.create_reference_table";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -592,13 +592,13 @@ impl ReferenceTablesAPI {
         datadog::Error<CreateReferenceTableUploadError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_reference_table_upload";
+        let local_operation_id = "v2.create_reference_table_upload";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/uploads",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -735,13 +735,13 @@ impl ReferenceTablesAPI {
         body: crate::datadogV2::model::BatchDeleteRowsRequestArray,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRowsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_rows";
+        let local_operation_id = "v2.delete_rows";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables/{id}/rows",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -866,13 +866,13 @@ impl ReferenceTablesAPI {
         id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTableError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_table";
+        let local_operation_id = "v2.delete_table";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -967,13 +967,13 @@ impl ReferenceTablesAPI {
         datadog::Error<GetRowsByIDError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rows_by_id";
+        let local_operation_id = "v2.get_rows_by_id";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables/{id}/rows",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1082,13 +1082,13 @@ impl ReferenceTablesAPI {
         datadog::Error<GetTableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_table";
+        let local_operation_id = "v2.get_table";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1193,7 +1193,7 @@ impl ReferenceTablesAPI {
         datadog::Error<ListReferenceTableRowsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_reference_table_rows";
+        let local_operation_id = "v2.list_reference_table_rows";
 
         // unbox and build optional parameters
         let page_limit = params.page_limit;
@@ -1203,7 +1203,7 @@ impl ReferenceTablesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables/{id}/rows/list",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1311,7 +1311,7 @@ impl ReferenceTablesAPI {
         datadog::Error<ListTablesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tables";
+        let local_operation_id = "v2.list_tables";
 
         // unbox and build optional parameters
         let page_limit = params.page_limit;
@@ -1325,7 +1325,7 @@ impl ReferenceTablesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1441,13 +1441,13 @@ impl ReferenceTablesAPI {
         body: crate::datadogV2::model::PatchTableRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateReferenceTableError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_reference_table";
+        let local_operation_id = "v2.update_reference_table";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1578,13 +1578,13 @@ impl ReferenceTablesAPI {
         body: crate::datadogV2::model::BatchUpsertRowsRequestArray,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpsertRowsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_rows";
+        let local_operation_id = "v2.upsert_rows";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reference-tables/tables/{id}/rows",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_report_schedules.rs
+++ b/src/datadogV2/api/api_report_schedules.rs
@@ -249,9 +249,9 @@ impl ReportSchedulesAPI {
         datadog::Error<CreateReportScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_report_schedule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_report_schedule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_report_schedule' is not enabled".to_string(),
@@ -263,7 +263,7 @@ impl ReportSchedulesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/schedule",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -417,13 +417,13 @@ impl ReportSchedulesAPI {
         datadog::Error<DeleteReportScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_report_schedule";
+        let local_operation_id = "v2.delete_report_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/schedule/{schedule_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_uuid = datadog::urlencode(schedule_uuid.to_string())
         );
         let mut local_req_builder =
@@ -528,13 +528,13 @@ impl ReportSchedulesAPI {
         datadog::Error<GetReportScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_report_schedule";
+        let local_operation_id = "v2.get_report_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/schedule/{schedule_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_uuid = datadog::urlencode(schedule_uuid.to_string())
         );
         let mut local_req_builder =
@@ -644,13 +644,13 @@ impl ReportSchedulesAPI {
         datadog::Error<GetReportSchedulesForResourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_report_schedules_for_resource";
+        let local_operation_id = "v2.get_report_schedules_for_resource";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/schedule/{resource_type}/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_type = datadog::urlencode(resource_type.to_string()),
             resource_id = datadog::urlencode(resource_id)
         );
@@ -761,13 +761,13 @@ impl ReportSchedulesAPI {
         datadog::Error<ListDatasetReportSchedulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_dataset_report_schedules";
+        let local_operation_id = "v2.list_dataset_report_schedules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/dataset/{dataset_id}/schedules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =
@@ -874,7 +874,7 @@ impl ReportSchedulesAPI {
         datadog::Error<ListReportSchedulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_report_schedules";
+        let local_operation_id = "v2.list_report_schedules";
 
         // unbox and build optional parameters
         let page_limit = params.page_limit;
@@ -887,7 +887,7 @@ impl ReportSchedulesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/schedule/list",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1021,9 +1021,9 @@ impl ReportSchedulesAPI {
         datadog::Error<PatchReportScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.patch_report_schedule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.patch_report_schedule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.patch_report_schedule' is not enabled".to_string(),
@@ -1035,7 +1035,7 @@ impl ReportSchedulesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/schedule/{schedule_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_uuid = datadog::urlencode(schedule_uuid.to_string())
         );
         let mut local_req_builder =
@@ -1187,13 +1187,13 @@ impl ReportSchedulesAPI {
         datadog::Error<PrintReportError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.print_report";
+        let local_operation_id = "v2.print_report";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/print",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1348,13 +1348,13 @@ impl ReportSchedulesAPI {
         datadog::Error<ToggleReportScheduleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.toggle_report_schedule";
+        let local_operation_id = "v2.toggle_report_schedule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/reporting/schedule/{schedule_uuid}/toggle",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             schedule_uuid = datadog::urlencode(schedule_uuid.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_reporting_and_sharing.rs
+++ b/src/datadogV2/api/api_reporting_and_sharing.rs
@@ -123,9 +123,9 @@ impl ReportingAndSharingAPI {
         datadog::Error<CreateSnapshotError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_snapshot";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_snapshot";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_snapshot' is not enabled".to_string(),
@@ -137,7 +137,7 @@ impl ReportingAndSharingAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/snapshot",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_restriction_policies.rs
+++ b/src/datadogV2/api/api_restriction_policies.rs
@@ -146,13 +146,13 @@ impl RestrictionPoliciesAPI {
         resource_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRestrictionPolicyError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_restriction_policy";
+        let local_operation_id = "v2.delete_restriction_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/restriction_policy/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id)
         );
         let mut local_req_builder =
@@ -251,13 +251,13 @@ impl RestrictionPoliciesAPI {
         datadog::Error<GetRestrictionPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_restriction_policy";
+        let local_operation_id = "v2.get_restriction_policy";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/restriction_policy/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id)
         );
         let mut local_req_builder =
@@ -489,7 +489,7 @@ impl RestrictionPoliciesAPI {
         datadog::Error<UpdateRestrictionPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_restriction_policy";
+        let local_operation_id = "v2.update_restriction_policy";
 
         // unbox and build optional parameters
         let allow_self_lockout = params.allow_self_lockout;
@@ -498,7 +498,7 @@ impl RestrictionPoliciesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/restriction_policy/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_id = datadog::urlencode(resource_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_roles.rs
+++ b/src/datadogV2/api/api_roles.rs
@@ -332,13 +332,13 @@ impl RolesAPI {
         datadog::Error<AddPermissionToRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_permission_to_role";
+        let local_operation_id = "v2.add_permission_to_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}/permissions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -487,13 +487,13 @@ impl RolesAPI {
         datadog::Error<AddUserToRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_user_to_role";
+        let local_operation_id = "v2.add_user_to_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}/users",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -640,13 +640,13 @@ impl RolesAPI {
         datadog::Error<CloneRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.clone_role";
+        let local_operation_id = "v2.clone_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}/clone",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -816,13 +816,13 @@ impl RolesAPI {
         datadog::Error<CreateRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_role";
+        let local_operation_id = "v2.create_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -956,13 +956,13 @@ impl RolesAPI {
         role_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRoleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_role";
+        let local_operation_id = "v2.delete_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -1054,13 +1054,13 @@ impl RolesAPI {
         datadog::Error<GetRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_role";
+        let local_operation_id = "v2.get_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -1156,13 +1156,13 @@ impl RolesAPI {
         datadog::Error<ListPermissionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_permissions";
+        let local_operation_id = "v2.list_permissions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/permissions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1264,13 +1264,13 @@ impl RolesAPI {
         datadog::Error<ListRolePermissionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_role_permissions";
+        let local_operation_id = "v2.list_role_permissions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}/permissions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -1369,9 +1369,9 @@ impl RolesAPI {
         datadog::Error<ListRoleTemplatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_role_templates";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_role_templates";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_role_templates' is not enabled".to_string(),
@@ -1383,7 +1383,7 @@ impl RolesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/roles/templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1483,7 +1483,7 @@ impl RolesAPI {
         datadog::Error<ListRoleUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_role_users";
+        let local_operation_id = "v2.list_role_users";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1495,7 +1495,7 @@ impl RolesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}/users",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -1610,7 +1610,7 @@ impl RolesAPI {
         datadog::Error<ListRolesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_roles";
+        let local_operation_id = "v2.list_roles";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1623,7 +1623,7 @@ impl RolesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/roles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1748,13 +1748,13 @@ impl RolesAPI {
         datadog::Error<RemovePermissionFromRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_permission_from_role";
+        let local_operation_id = "v2.remove_permission_from_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}/permissions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -1907,13 +1907,13 @@ impl RolesAPI {
         datadog::Error<RemoveUserFromRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_user_from_role";
+        let local_operation_id = "v2.remove_user_from_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}/users",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =
@@ -2060,13 +2060,13 @@ impl RolesAPI {
         datadog::Error<UpdateRoleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_role";
+        let local_operation_id = "v2.update_role";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/roles/{role_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             role_id = datadog::urlencode(role_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_rum.rs
+++ b/src/datadogV2/api/api_rum.rs
@@ -722,13 +722,13 @@ impl RUMAPI {
         datadog::Error<AggregateRUMEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.aggregate_rum_events";
+        let local_operation_id = "v2.aggregate_rum_events";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/analytics/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -877,13 +877,13 @@ impl RUMAPI {
         datadog::Error<CreateRUMApplicationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_rum_application";
+        let local_operation_id = "v2.create_rum_application";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1018,13 +1018,13 @@ impl RUMAPI {
         id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRUMApplicationError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_rum_application";
+        let local_operation_id = "v2.delete_rum_application";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1129,9 +1129,9 @@ impl RUMAPI {
         datadog::Error<DeleteSourcemapsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_sourcemaps";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_sourcemaps";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_sourcemaps' is not enabled".to_string(),
@@ -1163,7 +1163,7 @@ impl RUMAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/sourcemaps",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1365,13 +1365,13 @@ impl RUMAPI {
         datadog::Error<GetRUMApplicationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rum_application";
+        let local_operation_id = "v2.get_rum_application";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -1472,13 +1472,13 @@ impl RUMAPI {
         datadog::Error<GetRUMApplicationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rum_applications";
+        let local_operation_id = "v2.get_rum_applications";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1580,9 +1580,9 @@ impl RUMAPI {
         datadog::Error<GetServiceRepositoryInfoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_service_repository_info";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_service_repository_info";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_service_repository_info' is not enabled".to_string(),
@@ -1594,7 +1594,7 @@ impl RUMAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/sourcemaps/service_repository_info",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1750,9 +1750,9 @@ impl RUMAPI {
         datadog::Error<GetSourcemapsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_sourcemaps";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_sourcemaps";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_sourcemaps' is not enabled".to_string(),
@@ -1764,7 +1764,7 @@ impl RUMAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/sourcemaps",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1912,7 +1912,7 @@ impl RUMAPI {
         datadog::Error<ListRUMEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_rum_events";
+        let local_operation_id = "v2.list_rum_events";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -1926,7 +1926,7 @@ impl RUMAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2054,9 +2054,9 @@ impl RUMAPI {
         datadog::Error<ListSourcemapsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_sourcemaps";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_sourcemaps";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_sourcemaps' is not enabled".to_string(),
@@ -2091,7 +2091,7 @@ impl RUMAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/sourcemaps/list",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2312,9 +2312,9 @@ impl RUMAPI {
         datadog::Error<RestoreSourcemapsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.restore_sourcemaps";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.restore_sourcemaps";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.restore_sourcemaps' is not enabled".to_string(),
@@ -2346,7 +2346,7 @@ impl RUMAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/sourcemaps/restore",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -2593,13 +2593,13 @@ impl RUMAPI {
         datadog::Error<SearchRUMEventsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_rum_events";
+        let local_operation_id = "v2.search_rum_events";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2749,13 +2749,13 @@ impl RUMAPI {
         datadog::Error<UpdateRUMApplicationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_rum_application";
+        let local_operation_id = "v2.update_rum_application";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_rum_audience_management.rs
+++ b/src/datadogV2/api/api_rum_audience_management.rs
@@ -184,9 +184,9 @@ impl RumAudienceManagementAPI {
         body: crate::datadogV2::model::CreateConnectionRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateConnectionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_connection";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_connection";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_connection' is not enabled".to_string(),
@@ -198,7 +198,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/{entity}/mapping/connection",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             entity = datadog::urlencode(entity)
         );
         let mut local_req_builder =
@@ -329,9 +329,9 @@ impl RumAudienceManagementAPI {
         entity: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteConnectionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_connection";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_connection";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_connection' is not enabled".to_string(),
@@ -343,7 +343,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/{entity}/mapping/connection/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id),
             entity = datadog::urlencode(entity)
         );
@@ -438,9 +438,9 @@ impl RumAudienceManagementAPI {
         datadog::Error<GetAccountFacetInfoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_account_facet_info";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_account_facet_info";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_account_facet_info' is not enabled".to_string(),
@@ -452,7 +452,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/accounts/facet_info",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -597,9 +597,9 @@ impl RumAudienceManagementAPI {
         datadog::Error<GetMappingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_mapping";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_mapping";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_mapping' is not enabled".to_string(),
@@ -611,7 +611,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/{entity}/mapping",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             entity = datadog::urlencode(entity)
         );
         let mut local_req_builder =
@@ -711,9 +711,9 @@ impl RumAudienceManagementAPI {
         datadog::Error<GetUserFacetInfoError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_user_facet_info";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_user_facet_info";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_user_facet_info' is not enabled".to_string(),
@@ -725,7 +725,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/users/facet_info",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -873,9 +873,9 @@ impl RumAudienceManagementAPI {
         datadog::Error<ListConnectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_connections";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_connections";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_connections' is not enabled".to_string(),
@@ -887,7 +887,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/{entity}/mapping/connections",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             entity = datadog::urlencode(entity)
         );
         let mut local_req_builder =
@@ -987,9 +987,9 @@ impl RumAudienceManagementAPI {
         datadog::Error<QueryAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_accounts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.query_accounts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.query_accounts' is not enabled".to_string(),
@@ -1001,7 +1001,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/accounts/query",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1146,9 +1146,9 @@ impl RumAudienceManagementAPI {
         datadog::Error<QueryEventFilteredUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_event_filtered_users";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.query_event_filtered_users";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.query_event_filtered_users' is not enabled".to_string(),
@@ -1160,7 +1160,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/users/event_filtered_query",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1304,9 +1304,9 @@ impl RumAudienceManagementAPI {
         datadog::Error<QueryUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_users";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.query_users";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.query_users' is not enabled".to_string(),
@@ -1318,7 +1318,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/users/query",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1452,9 +1452,9 @@ impl RumAudienceManagementAPI {
         body: crate::datadogV2::model::UpdateConnectionRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateConnectionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_connection";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_connection";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_connection' is not enabled".to_string(),
@@ -1466,7 +1466,7 @@ impl RumAudienceManagementAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/product-analytics/{entity}/mapping/connection",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             entity = datadog::urlencode(entity)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_rum_insights.rs
+++ b/src/datadogV2/api/api_rum_insights.rs
@@ -143,9 +143,9 @@ impl RUMInsightsAPI {
         datadog::Error<QueryAggregatedLongTasksError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_aggregated_long_tasks";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.query_aggregated_long_tasks";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.query_aggregated_long_tasks' is not enabled".to_string(),
@@ -157,7 +157,7 @@ impl RUMInsightsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/query/insight/aggregated_long_tasks",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -309,9 +309,9 @@ impl RUMInsightsAPI {
         datadog::Error<QueryAggregatedSignalsProblemsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_aggregated_signals_problems";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.query_aggregated_signals_problems";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.query_aggregated_signals_problems' is not enabled".to_string(),
@@ -323,7 +323,7 @@ impl RUMInsightsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/query/insight/aggregated_signals_problems",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -472,9 +472,9 @@ impl RUMInsightsAPI {
         datadog::Error<QueryAggregatedWaterfallError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.query_aggregated_waterfall";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.query_aggregated_waterfall";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.query_aggregated_waterfall' is not enabled".to_string(),
@@ -486,7 +486,7 @@ impl RUMInsightsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/query/insight/aggregated_waterfall",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_rum_metrics.rs
+++ b/src/datadogV2/api/api_rum_metrics.rs
@@ -155,13 +155,13 @@ impl RumMetricsAPI {
         datadog::Error<CreateRumMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_rum_metric";
+        let local_operation_id = "v2.create_rum_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -295,13 +295,13 @@ impl RumMetricsAPI {
         metric_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRumMetricError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_rum_metric";
+        let local_operation_id = "v2.delete_rum_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =
@@ -394,13 +394,13 @@ impl RumMetricsAPI {
         datadog::Error<GetRumMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rum_metric";
+        let local_operation_id = "v2.get_rum_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =
@@ -497,13 +497,13 @@ impl RumMetricsAPI {
         datadog::Error<ListRumMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_rum_metrics";
+        let local_operation_id = "v2.list_rum_metrics";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -607,13 +607,13 @@ impl RumMetricsAPI {
         datadog::Error<UpdateRumMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_rum_metric";
+        let local_operation_id = "v2.update_rum_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_rum_rate_limit.rs
+++ b/src/datadogV2/api/api_rum_rate_limit.rs
@@ -131,9 +131,9 @@ impl RumRateLimitAPI {
         scope_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRumRateLimitConfigError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_rum_rate_limit_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_rum_rate_limit_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_rum_rate_limit_config' is not enabled".to_string(),
@@ -145,7 +145,7 @@ impl RumRateLimitAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/rate-limit/{scope_type}/{scope_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             scope_type = datadog::urlencode(scope_type.to_string()),
             scope_id = datadog::urlencode(scope_id)
         );
@@ -247,9 +247,9 @@ impl RumRateLimitAPI {
         datadog::Error<GetRumRateLimitConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rum_rate_limit_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_rum_rate_limit_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_rum_rate_limit_config' is not enabled".to_string(),
@@ -261,7 +261,7 @@ impl RumRateLimitAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/rate-limit/{scope_type}/{scope_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             scope_type = datadog::urlencode(scope_type.to_string()),
             scope_id = datadog::urlencode(scope_id)
         );
@@ -374,9 +374,9 @@ impl RumRateLimitAPI {
         datadog::Error<UpdateRumRateLimitConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_rum_rate_limit_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_rum_rate_limit_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_rum_rate_limit_config' is not enabled".to_string(),
@@ -388,7 +388,7 @@ impl RumRateLimitAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/config/rate-limit/{scope_type}/{scope_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             scope_type = datadog::urlencode(scope_type.to_string()),
             scope_id = datadog::urlencode(scope_id)
         );

--- a/src/datadogV2/api/api_rum_remote_config.rs
+++ b/src/datadogV2/api/api_rum_remote_config.rs
@@ -132,9 +132,9 @@ impl RUMRemoteConfigAPI {
         datadog::Error<GetRumSdkConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rum_sdk_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_rum_sdk_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_rum_sdk_config' is not enabled".to_string(),
@@ -146,7 +146,7 @@ impl RUMRemoteConfigAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/rum/configs/{config_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             config_id = datadog::urlencode(config_id)
         );
         let mut local_req_builder =
@@ -256,9 +256,9 @@ impl RUMRemoteConfigAPI {
         datadog::Error<UpdateRumSdkConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_rum_sdk_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_rum_sdk_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_rum_sdk_config' is not enabled".to_string(),
@@ -270,7 +270,7 @@ impl RUMRemoteConfigAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/remote_config/products/rum/configs/{config_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             config_id = datadog::urlencode(config_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_rum_replay_heatmaps.rs
+++ b/src/datadogV2/api/api_rum_replay_heatmaps.rs
@@ -178,13 +178,13 @@ impl RumReplayHeatmapsAPI {
         datadog::Error<CreateReplayHeatmapSnapshotError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_replay_heatmap_snapshot";
+        let local_operation_id = "v2.create_replay_heatmap_snapshot";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/replay/heatmap/snapshots",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -321,13 +321,13 @@ impl RumReplayHeatmapsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteReplayHeatmapSnapshotError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_replay_heatmap_snapshot";
+        let local_operation_id = "v2.delete_replay_heatmap_snapshot";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/replay/heatmap/snapshots/{snapshot_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             snapshot_id = datadog::urlencode(snapshot_id)
         );
         let mut local_req_builder =
@@ -428,7 +428,7 @@ impl RumReplayHeatmapsAPI {
         datadog::Error<ListReplayHeatmapSnapshotsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_replay_heatmap_snapshots";
+        let local_operation_id = "v2.list_replay_heatmap_snapshots";
 
         // unbox and build optional parameters
         let filter_device_type = params.filter_device_type;
@@ -439,7 +439,7 @@ impl RumReplayHeatmapsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/replay/heatmap/snapshots",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -557,13 +557,13 @@ impl RumReplayHeatmapsAPI {
         datadog::Error<UpdateReplayHeatmapSnapshotError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_replay_heatmap_snapshot";
+        let local_operation_id = "v2.update_replay_heatmap_snapshot";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/replay/heatmap/snapshots/{snapshot_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             snapshot_id = datadog::urlencode(snapshot_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_rum_replay_playlists.rs
+++ b/src/datadogV2/api/api_rum_replay_playlists.rs
@@ -272,7 +272,7 @@ impl RumReplayPlaylistsAPI {
         datadog::Error<AddRumReplaySessionToPlaylistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_rum_replay_session_to_playlist";
+        let local_operation_id = "v2.add_rum_replay_session_to_playlist";
 
         // unbox and build optional parameters
         let data_source = params.data_source;
@@ -281,7 +281,7 @@ impl RumReplayPlaylistsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists/{playlist_id}/sessions/{session_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             playlist_id = playlist_id,
             session_id = datadog::urlencode(session_id)
         );
@@ -384,13 +384,13 @@ impl RumReplayPlaylistsAPI {
         datadog::Error<BulkRemoveRumReplayPlaylistSessionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_remove_rum_replay_playlist_sessions";
+        let local_operation_id = "v2.bulk_remove_rum_replay_playlist_sessions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists/{playlist_id}/sessions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             playlist_id = playlist_id
         );
         let mut local_req_builder =
@@ -531,13 +531,13 @@ impl RumReplayPlaylistsAPI {
         datadog::Error<CreateRumReplayPlaylistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_rum_replay_playlist";
+        let local_operation_id = "v2.create_rum_replay_playlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -673,13 +673,13 @@ impl RumReplayPlaylistsAPI {
         playlist_id: i64,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRumReplayPlaylistError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_rum_replay_playlist";
+        let local_operation_id = "v2.delete_rum_replay_playlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists/{playlist_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             playlist_id = playlist_id
         );
         let mut local_req_builder =
@@ -775,13 +775,13 @@ impl RumReplayPlaylistsAPI {
         datadog::Error<GetRumReplayPlaylistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rum_replay_playlist";
+        let local_operation_id = "v2.get_rum_replay_playlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists/{playlist_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             playlist_id = playlist_id
         );
         let mut local_req_builder =
@@ -887,7 +887,7 @@ impl RumReplayPlaylistsAPI {
         datadog::Error<ListRumReplayPlaylistSessionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_rum_replay_playlist_sessions";
+        let local_operation_id = "v2.list_rum_replay_playlist_sessions";
 
         // unbox and build optional parameters
         let page_number = params.page_number;
@@ -897,7 +897,7 @@ impl RumReplayPlaylistsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists/{playlist_id}/sessions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             playlist_id = playlist_id
         );
         let mut local_req_builder =
@@ -1007,7 +1007,7 @@ impl RumReplayPlaylistsAPI {
         datadog::Error<ListRumReplayPlaylistsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_rum_replay_playlists";
+        let local_operation_id = "v2.list_rum_replay_playlists";
 
         // unbox and build optional parameters
         let filter_created_by_uuid = params.filter_created_by_uuid;
@@ -1019,7 +1019,7 @@ impl RumReplayPlaylistsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1128,13 +1128,13 @@ impl RumReplayPlaylistsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RemoveRumReplaySessionFromPlaylistError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_rum_replay_session_from_playlist";
+        let local_operation_id = "v2.remove_rum_replay_session_from_playlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists/{playlist_id}/sessions/{session_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             playlist_id = playlist_id,
             session_id = datadog::urlencode(session_id)
         );
@@ -1234,13 +1234,13 @@ impl RumReplayPlaylistsAPI {
         datadog::Error<UpdateRumReplayPlaylistError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_rum_replay_playlist";
+        let local_operation_id = "v2.update_rum_replay_playlist";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/playlists/{playlist_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             playlist_id = playlist_id
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_rum_replay_sessions.rs
+++ b/src/datadogV2/api/api_rum_replay_sessions.rs
@@ -148,7 +148,7 @@ impl RumReplaySessionsAPI {
         params: GetSegmentsOptionalParams,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<GetSegmentsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_segments";
+        let local_operation_id = "v2.get_segments";
 
         // unbox and build optional parameters
         let source = params.source;
@@ -160,7 +160,7 @@ impl RumReplaySessionsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/sessions/{session_id}/views/{view_id}/segments",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             view_id = datadog::urlencode(view_id),
             session_id = datadog::urlencode(session_id)
         );

--- a/src/datadogV2/api/api_rum_replay_viewership.rs
+++ b/src/datadogV2/api/api_rum_replay_viewership.rs
@@ -231,13 +231,13 @@ impl RumReplayViewershipAPI {
         datadog::Error<CreateRumReplaySessionWatchError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_rum_replay_session_watch";
+        let local_operation_id = "v2.create_rum_replay_session_watch";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/sessions/{session_id}/watches",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             session_id = datadog::urlencode(session_id)
         );
         let mut local_req_builder =
@@ -375,13 +375,13 @@ impl RumReplayViewershipAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRumReplaySessionWatchError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_rum_replay_session_watch";
+        let local_operation_id = "v2.delete_rum_replay_session_watch";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/sessions/{session_id}/watches",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             session_id = datadog::urlencode(session_id)
         );
         let mut local_req_builder =
@@ -482,7 +482,7 @@ impl RumReplayViewershipAPI {
         datadog::Error<ListRumReplaySessionWatchersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_rum_replay_session_watchers";
+        let local_operation_id = "v2.list_rum_replay_session_watchers";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -492,7 +492,7 @@ impl RumReplayViewershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/sessions/{session_id}/watchers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             session_id = datadog::urlencode(session_id)
         );
         let mut local_req_builder =
@@ -605,7 +605,7 @@ impl RumReplayViewershipAPI {
         datadog::Error<ListRumReplayViewershipHistorySessionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_rum_replay_viewership_history_sessions";
+        let local_operation_id = "v2.list_rum_replay_viewership_history_sessions";
 
         // unbox and build optional parameters
         let filter_watched_at_start = params.filter_watched_at_start;
@@ -620,7 +620,7 @@ impl RumReplayViewershipAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/rum/replay/viewership-history/sessions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_rum_retention_filters.rs
+++ b/src/datadogV2/api/api_rum_retention_filters.rs
@@ -194,13 +194,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<CreateRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_retention_filter";
+        let local_operation_id = "v2.create_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id)
         );
         let mut local_req_builder =
@@ -341,13 +341,13 @@ impl RumRetentionFiltersAPI {
         rf_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteRetentionFilterError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_retention_filter";
+        let local_operation_id = "v2.delete_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters/{rf_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id),
             rf_id = datadog::urlencode(rf_id)
         );
@@ -449,13 +449,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<GetPermanentRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_permanent_retention_filter";
+        let local_operation_id = "v2.get_permanent_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters/permanent/{permanent_rf_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id),
             permanent_rf_id = datadog::urlencode(permanent_rf_id.to_string())
         );
@@ -564,13 +564,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<GetRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_retention_filter";
+        let local_operation_id = "v2.get_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters/{rf_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id),
             rf_id = datadog::urlencode(rf_id)
         );
@@ -681,13 +681,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<ListPermanentRetentionFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_permanent_retention_filters";
+        let local_operation_id = "v2.list_permanent_retention_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters/permanent",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id)
         );
         let mut local_req_builder =
@@ -791,13 +791,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<ListRetentionFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_retention_filters";
+        let local_operation_id = "v2.list_retention_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id)
         );
         let mut local_req_builder =
@@ -907,13 +907,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<OrderRetentionFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.order_retention_filters";
+        let local_operation_id = "v2.order_retention_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/relationships/retention_filters",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id)
         );
         let mut local_req_builder =
@@ -1074,13 +1074,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<UpdatePermanentRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_permanent_retention_filter";
+        let local_operation_id = "v2.update_permanent_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters/permanent/{permanent_rf_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id),
             permanent_rf_id = datadog::urlencode(permanent_rf_id.to_string())
         );
@@ -1240,13 +1240,13 @@ impl RumRetentionFiltersAPI {
         datadog::Error<UpdateRetentionFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_retention_filter";
+        let local_operation_id = "v2.update_retention_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/rum/applications/{app_id}/retention_filters/{rf_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             app_id = datadog::urlencode(app_id),
             rf_id = datadog::urlencode(rf_id)
         );

--- a/src/datadogV2/api/api_salesforce_integration.rs
+++ b/src/datadogV2/api/api_salesforce_integration.rs
@@ -166,13 +166,13 @@ impl SalesforceIntegrationAPI {
         datadog::Error<CreateIncidentTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_incident_template";
+        let local_operation_id = "v2.create_incident_template";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/salesforce-incidents/incident-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -310,13 +310,13 @@ impl SalesforceIntegrationAPI {
         incident_template_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteIncidentTemplateError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_incident_template";
+        let local_operation_id = "v2.delete_incident_template";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/salesforce-incidents/incident-templates/{incident_template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_template_id = datadog::urlencode(incident_template_id)
         );
         let mut local_req_builder =
@@ -404,13 +404,13 @@ impl SalesforceIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSalesforceOrganizationError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_salesforce_organization";
+        let local_operation_id = "v2.delete_salesforce_organization";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/salesforce-incidents/organizations/{salesforce_org_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             salesforce_org_id = datadog::urlencode(salesforce_org_id)
         );
         let mut local_req_builder =
@@ -504,13 +504,13 @@ impl SalesforceIntegrationAPI {
         datadog::Error<GetIncidentTemplatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_incident_templates";
+        let local_operation_id = "v2.get_incident_templates";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/salesforce-incidents/incident-templates",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -615,13 +615,13 @@ impl SalesforceIntegrationAPI {
         datadog::Error<GetSalesforceOrganizationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_salesforce_organizations";
+        let local_operation_id = "v2.get_salesforce_organizations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/salesforce-incidents/organizations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -729,13 +729,13 @@ impl SalesforceIntegrationAPI {
         datadog::Error<UpdateIncidentTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_incident_template";
+        let local_operation_id = "v2.update_incident_template";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/salesforce-incidents/incident-templates/{incident_template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             incident_template_id = datadog::urlencode(incident_template_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_scorecards.rs
+++ b/src/datadogV2/api/api_scorecards.rs
@@ -577,13 +577,13 @@ impl ScorecardsAPI {
         datadog::Error<CreateScorecardCampaignError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_scorecard_campaign";
+        let local_operation_id = "v2.create_scorecard_campaign";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/campaigns",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -734,9 +734,9 @@ impl ScorecardsAPI {
         datadog::Error<CreateScorecardOutcomesBatchError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_scorecard_outcomes_batch";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_scorecard_outcomes_batch";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_scorecard_outcomes_batch' is not enabled".to_string(),
@@ -748,7 +748,7 @@ impl ScorecardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/outcomes/batch",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -895,13 +895,13 @@ impl ScorecardsAPI {
         datadog::Error<CreateScorecardRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_scorecard_rule";
+        let local_operation_id = "v2.create_scorecard_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1039,13 +1039,13 @@ impl ScorecardsAPI {
         campaign_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteScorecardCampaignError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_scorecard_campaign";
+        let local_operation_id = "v2.delete_scorecard_campaign";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/campaigns/{campaign_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             campaign_id = datadog::urlencode(campaign_id)
         );
         let mut local_req_builder =
@@ -1127,13 +1127,13 @@ impl ScorecardsAPI {
         rule_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteScorecardRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_scorecard_rule";
+        let local_operation_id = "v2.delete_scorecard_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -1232,7 +1232,7 @@ impl ScorecardsAPI {
         datadog::Error<GetScorecardCampaignError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_scorecard_campaign";
+        let local_operation_id = "v2.get_scorecard_campaign";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1242,7 +1242,7 @@ impl ScorecardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/campaigns/{campaign_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             campaign_id = datadog::urlencode(campaign_id)
         );
         let mut local_req_builder =
@@ -1353,7 +1353,7 @@ impl ScorecardsAPI {
         datadog::Error<ListScorecardCampaignsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_scorecard_campaigns";
+        let local_operation_id = "v2.list_scorecard_campaigns";
 
         // unbox and build optional parameters
         let page_limit = params.page_limit;
@@ -1366,7 +1366,7 @@ impl ScorecardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/campaigns",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1524,7 +1524,7 @@ impl ScorecardsAPI {
         datadog::Error<ListScorecardOutcomesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_scorecard_outcomes";
+        let local_operation_id = "v2.list_scorecard_outcomes";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1542,7 +1542,7 @@ impl ScorecardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/outcomes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1721,7 +1721,7 @@ impl ScorecardsAPI {
         datadog::Error<ListScorecardRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_scorecard_rules";
+        let local_operation_id = "v2.list_scorecard_rules";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1739,7 +1739,7 @@ impl ScorecardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1886,7 +1886,7 @@ impl ScorecardsAPI {
         datadog::Error<ListScorecardScoresError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_scorecard_scores";
+        let local_operation_id = "v2.list_scorecard_scores";
 
         // unbox and build optional parameters
         let filter_rule_id = params.filter_rule_id;
@@ -1903,7 +1903,7 @@ impl ScorecardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/scores/{aggregation}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             aggregation = datadog::urlencode(aggregation.to_string())
         );
         let mut local_req_builder =
@@ -2041,7 +2041,7 @@ impl ScorecardsAPI {
         datadog::Error<ListScorecardsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_scorecards";
+        let local_operation_id = "v2.list_scorecards";
 
         // unbox and build optional parameters
         let page_offset = params.page_offset;
@@ -2054,7 +2054,7 @@ impl ScorecardsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/scorecards",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2184,13 +2184,13 @@ impl ScorecardsAPI {
         datadog::Error<UpdateScorecardCampaignError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_scorecard_campaign";
+        let local_operation_id = "v2.update_scorecard_campaign";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/campaigns/{campaign_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             campaign_id = datadog::urlencode(campaign_id)
         );
         let mut local_req_builder =
@@ -2325,13 +2325,13 @@ impl ScorecardsAPI {
         body: crate::datadogV2::model::UpdateOutcomesAsyncRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateScorecardOutcomesError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_scorecard_outcomes";
+        let local_operation_id = "v2.update_scorecard_outcomes";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/outcomes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2476,13 +2476,13 @@ impl ScorecardsAPI {
         datadog::Error<UpdateScorecardRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_scorecard_rule";
+        let local_operation_id = "v2.update_scorecard_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/scorecard/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_seats.rs
+++ b/src/datadogV2/api/api_seats.rs
@@ -162,13 +162,13 @@ impl SeatsAPI {
         datadog::Error<AssignSeatsUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.assign_seats_user";
+        let local_operation_id = "v2.assign_seats_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/seats/users",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -320,7 +320,7 @@ impl SeatsAPI {
         datadog::Error<GetSeatsUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_seats_users";
+        let local_operation_id = "v2.get_seats_users";
 
         // unbox and build optional parameters
         let page_limit = params.page_limit;
@@ -330,7 +330,7 @@ impl SeatsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/seats/users",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -427,13 +427,13 @@ impl SeatsAPI {
         body: crate::datadogV2::model::UnassignSeatsUserRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnassignSeatsUserError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unassign_seats_user";
+        let local_operation_id = "v2.unassign_seats_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/seats/users",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());

--- a/src/datadogV2/api/api_security_monitoring.rs
+++ b/src/datadogV2/api/api_security_monitoring.rs
@@ -2994,9 +2994,9 @@ impl SecurityMonitoringAPI {
         content_pack_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ActivateContentPackError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.activate_content_pack";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.activate_content_pack";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.activate_content_pack' is not enabled".to_string(),
@@ -3008,7 +3008,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/content_packs/{content_pack_id}/activate",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             content_pack_id = datadog::urlencode(content_pack_id)
         );
         let mut local_req_builder =
@@ -3115,9 +3115,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ActivateIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.activate_integration";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.activate_integration";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.activate_integration' is not enabled".to_string(),
@@ -3132,7 +3132,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/{integration_type}/activate",
-            local_configuration.get_operation_host(operation_id), integration_type=
+            local_configuration.get_operation_host(local_operation_id), integration_type=
             datadog::urlencode(integration_type)
             );
         let mut local_req_builder =
@@ -3284,13 +3284,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<AttachCaseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.attach_case";
+        let local_operation_id = "v2.attach_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/cases/{case_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             case_id = datadog::urlencode(case_id)
         );
         let mut local_req_builder =
@@ -3439,13 +3439,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<AttachJiraIssueError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.attach_jira_issue";
+        let local_operation_id = "v2.attach_jira_issue";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/jira_issues",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -3594,13 +3594,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<AttachLinearIssueError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.attach_linear_issue";
+        let local_operation_id = "v2.attach_linear_issue";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/linear_issues",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -3751,13 +3751,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<AttachServiceNowTicketError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.attach_service_now_ticket";
+        let local_operation_id = "v2.attach_service_now_ticket";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/servicenow_tickets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -3913,9 +3913,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<BatchGetSecurityMonitoringDatasetDependenciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.batch_get_security_monitoring_dataset_dependencies";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.batch_get_security_monitoring_dataset_dependencies";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.batch_get_security_monitoring_dataset_dependencies' is not enabled".to_string(),
@@ -3927,7 +3927,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets/dependencies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4087,13 +4087,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkConvertExistingSecurityMonitoringRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_convert_existing_security_monitoring_rules";
+        let local_operation_id = "v2.bulk_convert_existing_security_monitoring_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/convert/bulk",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4252,9 +4252,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkCreateSampleLogGenerationSubscriptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_create_sample_log_generation_subscriptions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.bulk_create_sample_log_generation_subscriptions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg:
@@ -4268,7 +4268,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/sample_log_generation/subscriptions/bulk",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4421,13 +4421,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkDeleteSecurityMonitoringRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_delete_security_monitoring_rules";
+        let local_operation_id = "v2.bulk_delete_security_monitoring_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/bulk_delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -4584,13 +4584,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkEditSecurityMonitoringSignalsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_edit_security_monitoring_signals";
+        let local_operation_id = "v2.bulk_edit_security_monitoring_signals";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/bulk/update",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -4747,13 +4747,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkEditSecurityMonitoringSignalsAssigneeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_edit_security_monitoring_signals_assignee";
+        let local_operation_id = "v2.bulk_edit_security_monitoring_signals_assignee";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/bulk/assignee",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -4910,13 +4910,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkEditSecurityMonitoringSignalsStateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_edit_security_monitoring_signals_state";
+        let local_operation_id = "v2.bulk_edit_security_monitoring_signals_state";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/bulk/state",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -5070,13 +5070,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkExportSecurityMonitoringRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_export_security_monitoring_rules";
+        let local_operation_id = "v2.bulk_export_security_monitoring_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/bulk_export",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -5228,9 +5228,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<BulkExportSecurityMonitoringTerraformResourcesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.bulk_export_security_monitoring_terraform_resources";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.bulk_export_security_monitoring_terraform_resources";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.bulk_export_security_monitoring_terraform_resources' is not enabled".to_string(),
@@ -5242,7 +5242,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/terraform/{resource_type}/bulk",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_type = datadog::urlencode(resource_type.to_string())
         );
         let mut local_req_builder =
@@ -5371,9 +5371,9 @@ impl SecurityMonitoringAPI {
         job_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CancelHistoricalJobError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.cancel_historical_job";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.cancel_historical_job";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.cancel_historical_job' is not enabled".to_string(),
@@ -5385,7 +5385,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/jobs/{job_id}/cancel",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             job_id = datadog::urlencode(job_id)
         );
         let mut local_req_builder =
@@ -5496,13 +5496,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<ConvertExistingSecurityMonitoringRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.convert_existing_security_monitoring_rule";
+        let local_operation_id = "v2.convert_existing_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/{rule_id}/convert",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -5592,9 +5592,9 @@ impl SecurityMonitoringAPI {
         body: crate::datadogV2::model::ConvertJobResultsToSignalsRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ConvertJobResultToSignalError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.convert_job_result_to_signal";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.convert_job_result_to_signal";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.convert_job_result_to_signal' is not enabled".to_string(),
@@ -5606,7 +5606,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/jobs/signal_convert",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -5763,13 +5763,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<ConvertSecurityMonitoringRuleFromJSONToTerraformError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.convert_security_monitoring_rule_from_json_to_terraform";
+        let local_operation_id = "v2.convert_security_monitoring_rule_from_json_to_terraform";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/convert",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -5930,9 +5930,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ConvertSecurityMonitoringTerraformResourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.convert_security_monitoring_terraform_resource";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.convert_security_monitoring_terraform_resource";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.convert_security_monitoring_terraform_resource' is not enabled"
@@ -5945,7 +5945,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/terraform/{resource_type}/convert",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_type = datadog::urlencode(resource_type.to_string())
         );
         let mut local_req_builder =
@@ -6096,13 +6096,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateCasesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_cases";
+        let local_operation_id = "v2.create_cases";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/cases",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -6250,13 +6250,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateCustomFrameworkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_custom_framework";
+        let local_operation_id = "v2.create_custom_framework";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_security_management/custom_frameworks",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -6407,9 +6407,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateIoCTriageStateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_io_c_triage_state";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_io_c_triage_state";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_io_c_triage_state' is not enabled".to_string(),
@@ -6421,7 +6421,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/siem/ioc-explorer/triage",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -6572,13 +6572,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateJiraIssuesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_jira_issues";
+        let local_operation_id = "v2.create_jira_issues";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/jira_issues",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -6729,13 +6729,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateLinearIssuesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_linear_issues";
+        let local_operation_id = "v2.create_linear_issues";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/linear_issues",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -6899,9 +6899,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSampleLogGenerationSubscriptionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_sample_log_generation_subscription";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_sample_log_generation_subscription";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_sample_log_generation_subscription' is not enabled"
@@ -6914,7 +6914,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/sample_log_generation/subscriptions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -7070,13 +7070,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_filter";
+        let local_operation_id = "v2.create_security_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/security_filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -7228,9 +7228,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityFindingsAutomationDueDateRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_findings_automation_due_date_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_security_findings_automation_due_date_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_security_findings_automation_due_date_rule' is not enabled".to_string(),
@@ -7242,7 +7242,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/due_date_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -7394,9 +7394,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityFindingsAutomationMuteRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_findings_automation_mute_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_security_findings_automation_mute_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_security_findings_automation_mute_rule' is not enabled"
@@ -7409,7 +7409,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/mute_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -7560,9 +7560,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityFindingsAutomationTicketCreationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_findings_automation_ticket_creation_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_security_findings_automation_ticket_creation_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_security_findings_automation_ticket_creation_rule' is not enabled".to_string(),
@@ -7574,7 +7574,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/ticket_creation_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -7726,13 +7726,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityMonitoringCriticalAssetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_monitoring_critical_asset";
+        let local_operation_id = "v2.create_security_monitoring_critical_asset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/critical_assets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -7887,9 +7887,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityMonitoringDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_monitoring_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_security_monitoring_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_security_monitoring_dataset' is not enabled".to_string(),
@@ -7901,7 +7901,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8060,9 +8060,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityMonitoringIntegrationConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_monitoring_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_security_monitoring_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_security_monitoring_integration_config' is not enabled"
@@ -8075,7 +8075,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8228,13 +8228,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityMonitoringRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_monitoring_rule";
+        let local_operation_id = "v2.create_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8386,13 +8386,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSecurityMonitoringSuppressionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_security_monitoring_suppression";
+        let local_operation_id = "v2.create_security_monitoring_suppression";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8544,13 +8544,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateServiceNowTicketsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_service_now_tickets";
+        let local_operation_id = "v2.create_service_now_tickets";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/servicenow_tickets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8702,13 +8702,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateSignalNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_signal_notification_rule";
+        let local_operation_id = "v2.create_signal_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/signals/notification_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -8855,9 +8855,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateStaticAnalysisAstError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_static_analysis_ast";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_static_analysis_ast";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_static_analysis_ast' is not enabled".to_string(),
@@ -8869,7 +8869,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/static-analysis-server/get-ast",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -9019,9 +9019,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateStaticAnalysisServerAnalysisError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_static_analysis_server_analysis";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_static_analysis_server_analysis";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_static_analysis_server_analysis' is not enabled"
@@ -9034,7 +9034,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/static-analysis-server/analyze",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -9185,13 +9185,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<CreateVulnerabilityNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_vulnerability_notification_rule";
+        let local_operation_id = "v2.create_vulnerability_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerabilities/notification_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -9331,9 +9331,9 @@ impl SecurityMonitoringAPI {
         content_pack_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeactivateContentPackError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.deactivate_content_pack";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.deactivate_content_pack";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.deactivate_content_pack' is not enabled".to_string(),
@@ -9345,7 +9345,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/content_packs/{content_pack_id}/deactivate",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             content_pack_id = datadog::urlencode(content_pack_id)
         );
         let mut local_req_builder =
@@ -9446,9 +9446,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeactivateIntegrationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.deactivate_integration";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.deactivate_integration";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.deactivate_integration' is not enabled".to_string(),
@@ -9460,7 +9460,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/{integration_type}/deactivate",
-            local_configuration.get_operation_host(operation_id), integration_type=
+            local_configuration.get_operation_host(local_operation_id), integration_type=
             datadog::urlencode(integration_type)
             );
         let mut local_req_builder =
@@ -9569,13 +9569,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteCustomFrameworkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_custom_framework";
+        let local_operation_id = "v2.delete_custom_framework";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_security_management/custom_frameworks/{handle}/{version}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle = datadog::urlencode(handle),
             version = datadog::urlencode(version)
         );
@@ -9665,9 +9665,9 @@ impl SecurityMonitoringAPI {
         job_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteHistoricalJobError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_historical_job";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_historical_job";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_historical_job' is not enabled".to_string(),
@@ -9679,7 +9679,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/jobs/{job_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             job_id = datadog::urlencode(job_id)
         );
         let mut local_req_builder =
@@ -9788,9 +9788,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteSampleLogGenerationSubscriptionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_sample_log_generation_subscription";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_sample_log_generation_subscription";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_sample_log_generation_subscription' is not enabled"
@@ -9803,7 +9803,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/sample_log_generation/subscriptions/{content_pack_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             content_pack_id = datadog::urlencode(content_pack_id)
         );
         let mut local_req_builder =
@@ -9896,13 +9896,13 @@ impl SecurityMonitoringAPI {
         security_filter_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSecurityFilterError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_filter";
+        let local_operation_id = "v2.delete_security_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/security_filters/{security_filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             security_filter_id = datadog::urlencode(security_filter_id)
         );
         let mut local_req_builder =
@@ -9990,9 +9990,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteSecurityFindingsAutomationDueDateRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_findings_automation_due_date_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_security_findings_automation_due_date_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_security_findings_automation_due_date_rule' is not enabled".to_string(),
@@ -10004,7 +10004,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/due_date_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -10092,9 +10092,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteSecurityFindingsAutomationMuteRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_findings_automation_mute_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_security_findings_automation_mute_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_security_findings_automation_mute_rule' is not enabled"
@@ -10107,7 +10107,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/mute_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -10195,9 +10195,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteSecurityFindingsAutomationTicketCreationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_findings_automation_ticket_creation_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_security_findings_automation_ticket_creation_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_security_findings_automation_ticket_creation_rule' is not enabled".to_string(),
@@ -10209,7 +10209,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/ticket_creation_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -10297,13 +10297,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteSecurityMonitoringCriticalAssetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_monitoring_critical_asset";
+        let local_operation_id = "v2.delete_security_monitoring_critical_asset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/critical_assets/{critical_asset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             critical_asset_id = datadog::urlencode(critical_asset_id)
         );
         let mut local_req_builder =
@@ -10391,9 +10391,9 @@ impl SecurityMonitoringAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSecurityMonitoringDatasetError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_monitoring_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_security_monitoring_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_security_monitoring_dataset' is not enabled".to_string(),
@@ -10405,7 +10405,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets/{dataset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =
@@ -10495,9 +10495,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteSecurityMonitoringIntegrationConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_monitoring_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_security_monitoring_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_security_monitoring_integration_config' is not enabled"
@@ -10510,7 +10510,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/{integration_config_id}",
-            local_configuration.get_operation_host(operation_id), integration_config_id=
+            local_configuration.get_operation_host(local_operation_id), integration_config_id=
             datadog::urlencode(integration_config_id)
             );
         let mut local_req_builder =
@@ -10596,13 +10596,13 @@ impl SecurityMonitoringAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSecurityMonitoringRuleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_monitoring_rule";
+        let local_operation_id = "v2.delete_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -10690,13 +10690,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteSecurityMonitoringSuppressionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_security_monitoring_suppression";
+        let local_operation_id = "v2.delete_security_monitoring_suppression";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions/{suppression_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             suppression_id = datadog::urlencode(suppression_id)
         );
         let mut local_req_builder =
@@ -10782,13 +10782,13 @@ impl SecurityMonitoringAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSignalNotificationRuleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_signal_notification_rule";
+        let local_operation_id = "v2.delete_signal_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/signals/notification_rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -10876,13 +10876,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<DeleteVulnerabilityNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_vulnerability_notification_rule";
+        let local_operation_id = "v2.delete_vulnerability_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerabilities/notification_rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -10966,13 +10966,13 @@ impl SecurityMonitoringAPI {
         body: crate::datadogV2::model::DetachCaseRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DetachCaseError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.detach_case";
+        let local_operation_id = "v2.detach_case";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/cases",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -11120,13 +11120,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<EditSecurityMonitoringSignalError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.edit_security_monitoring_signal";
+        let local_operation_id = "v2.edit_security_monitoring_signal";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}/update",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -11284,13 +11284,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<EditSecurityMonitoringSignalAssigneeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.edit_security_monitoring_signal_assignee";
+        let local_operation_id = "v2.edit_security_monitoring_signal_assignee";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}/assignee",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -11448,13 +11448,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<EditSecurityMonitoringSignalIncidentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.edit_security_monitoring_signal_incidents";
+        let local_operation_id = "v2.edit_security_monitoring_signal_incidents";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}/incidents",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -11612,13 +11612,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<EditSecurityMonitoringSignalStateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.edit_security_monitoring_signal_state";
+        let local_operation_id = "v2.edit_security_monitoring_signal_state";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}/state",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -11785,9 +11785,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ExportSecurityMonitoringTerraformResourceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.export_security_monitoring_terraform_resource";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.export_security_monitoring_terraform_resource";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.export_security_monitoring_terraform_resource' is not enabled"
@@ -11800,7 +11800,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/terraform/{resource_type}/{resource_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             resource_type = datadog::urlencode(resource_type.to_string()),
             resource_id = datadog::urlencode(resource_id)
         );
@@ -11907,9 +11907,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetContentPacksStatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_content_packs_states";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_content_packs_states";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_content_packs_states' is not enabled".to_string(),
@@ -11921,7 +11921,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/content_packs/states",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -12027,13 +12027,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetCriticalAssetsAffectingRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_critical_assets_affecting_rule";
+        let local_operation_id = "v2.get_critical_assets_affecting_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/critical_assets/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -12142,13 +12142,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetCustomFrameworkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_custom_framework";
+        let local_operation_id = "v2.get_custom_framework";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_security_management/custom_frameworks/{handle}/{version}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle = datadog::urlencode(handle),
             version = datadog::urlencode(version)
         );
@@ -12256,9 +12256,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetEntityContextError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_entity_context";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_entity_context";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_entity_context' is not enabled".to_string(),
@@ -12278,7 +12278,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/entity_context",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -12409,9 +12409,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetEntraIdAzureAppRegistrationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_entra_id_azure_app_registrations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_entra_id_azure_app_registrations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_entra_id_azure_app_registrations' is not enabled"
@@ -12424,7 +12424,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/entra_id/azure_app_registrations",
-            local_configuration.get_operation_host(operation_id));
+            local_configuration.get_operation_host(local_operation_id));
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
 
@@ -12525,9 +12525,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetFindingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_finding";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_finding";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_finding' is not enabled".to_string(),
@@ -12542,7 +12542,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/posture_management/findings/{finding_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             finding_id = datadog::urlencode(finding_id)
         );
         let mut local_req_builder =
@@ -12647,9 +12647,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetHistoricalJobError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_historical_job";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_historical_job";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_historical_job' is not enabled".to_string(),
@@ -12661,7 +12661,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/jobs/{job_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             job_id = datadog::urlencode(job_id)
         );
         let mut local_req_builder =
@@ -12769,9 +12769,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetIndicatorOfCompromiseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_indicator_of_compromise";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_indicator_of_compromise";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_indicator_of_compromise' is not enabled".to_string(),
@@ -12789,7 +12789,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/siem/ioc-explorer/indicator",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -12914,13 +12914,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetInvestigationLogQueriesMatchingSignalError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_investigation_log_queries_matching_signal";
+        let local_operation_id = "v2.get_investigation_log_queries_matching_signal";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}/investigation_queries",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -13027,7 +13027,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetResourceEvaluationFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_resource_evaluation_filters";
+        let local_operation_id = "v2.get_resource_evaluation_filters";
 
         // unbox and build optional parameters
         let cloud_provider = params.cloud_provider;
@@ -13038,7 +13038,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_security_management/resource_filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -13159,9 +13159,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetRuleVersionHistoryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_rule_version_history";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_rule_version_history";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_rule_version_history' is not enabled".to_string(),
@@ -13177,7 +13177,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/{rule_id}/version_history",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -13293,7 +13293,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSBOMError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_sbom";
+        let local_operation_id = "v2.get_sbom";
 
         // unbox and build optional parameters
         let filter_repo_digest = params.filter_repo_digest;
@@ -13303,7 +13303,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/sboms/{asset_type}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             asset_type = datadog::urlencode(asset_type.to_string())
         );
         let mut local_req_builder =
@@ -13410,9 +13410,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecretsRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_secrets_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_secrets_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_secrets_rules' is not enabled".to_string(),
@@ -13424,7 +13424,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/secrets/rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -13533,13 +13533,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_filter";
+        let local_operation_id = "v2.get_security_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/security_filters/{security_filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             security_filter_id = datadog::urlencode(security_filter_id)
         );
         let mut local_req_builder =
@@ -13645,9 +13645,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityFindingsAutomationDueDateRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_findings_automation_due_date_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_findings_automation_due_date_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_findings_automation_due_date_rule' is not enabled"
@@ -13660,7 +13660,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/due_date_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -13766,9 +13766,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityFindingsAutomationMuteRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_findings_automation_mute_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_findings_automation_mute_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_findings_automation_mute_rule' is not enabled"
@@ -13781,7 +13781,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/mute_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -13886,9 +13886,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityFindingsAutomationTicketCreationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_findings_automation_ticket_creation_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_findings_automation_ticket_creation_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_findings_automation_ticket_creation_rule' is not enabled".to_string(),
@@ -13900,7 +13900,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/ticket_creation_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -14006,13 +14006,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringCriticalAssetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_critical_asset";
+        let local_operation_id = "v2.get_security_monitoring_critical_asset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/critical_assets/{critical_asset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             critical_asset_id = datadog::urlencode(critical_asset_id)
         );
         let mut local_req_builder =
@@ -14119,9 +14119,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringDatasetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_monitoring_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_monitoring_dataset' is not enabled".to_string(),
@@ -14133,7 +14133,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets/{dataset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =
@@ -14241,9 +14241,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringDatasetByVersionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_dataset_by_version";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_monitoring_dataset_by_version";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_monitoring_dataset_by_version' is not enabled"
@@ -14256,7 +14256,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets/{dataset_id}/version/{version}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id),
             version = version
         );
@@ -14367,9 +14367,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringDatasetVersionHistoryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_dataset_version_history";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_monitoring_dataset_version_history";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg:
@@ -14387,7 +14387,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets/{dataset_id}/version_history",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =
@@ -14503,9 +14503,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringHistsignalError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_histsignal";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_monitoring_histsignal";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_monitoring_histsignal' is not enabled".to_string(),
@@ -14517,7 +14517,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/histsignals/{histsignal_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             histsignal_id = datadog::urlencode(histsignal_id)
         );
         let mut local_req_builder =
@@ -14625,9 +14625,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringHistsignalsByJobIdError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_histsignals_by_job_id";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_monitoring_histsignals_by_job_id";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_monitoring_histsignals_by_job_id' is not enabled"
@@ -14648,7 +14648,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/jobs/{job_id}/histsignals",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             job_id = datadog::urlencode(job_id)
         );
         let mut local_req_builder =
@@ -14786,9 +14786,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringIntegrationConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_security_monitoring_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_security_monitoring_integration_config' is not enabled"
@@ -14801,7 +14801,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/{integration_config_id}",
-            local_configuration.get_operation_host(operation_id), integration_config_id=
+            local_configuration.get_operation_host(local_operation_id), integration_config_id=
             datadog::urlencode(integration_config_id)
             );
         let mut local_req_builder =
@@ -14908,13 +14908,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_rule";
+        let local_operation_id = "v2.get_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -15020,13 +15020,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringSignalError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_signal";
+        let local_operation_id = "v2.get_security_monitoring_signal";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -15132,13 +15132,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSecurityMonitoringSuppressionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_security_monitoring_suppression";
+        let local_operation_id = "v2.get_security_monitoring_suppression";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions/{suppression_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             suppression_id = datadog::urlencode(suppression_id)
         );
         let mut local_req_builder =
@@ -15247,9 +15247,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSignalEntitiesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_signal_entities";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_signal_entities";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_signal_entities' is not enabled".to_string(),
@@ -15264,7 +15264,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}/entities",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -15372,13 +15372,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSignalNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_signal_notification_rule";
+        let local_operation_id = "v2.get_signal_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/signals/notification_rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -15479,13 +15479,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSignalNotificationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_signal_notification_rules";
+        let local_operation_id = "v2.get_signal_notification_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/signals/notification_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -15598,9 +15598,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSingleEntityContextError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_single_entity_context";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_single_entity_context";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_single_entity_context' is not enabled".to_string(),
@@ -15617,7 +15617,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/entity_context/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -15735,9 +15735,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetStaticAnalysisDefaultRulesetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_static_analysis_default_rulesets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_static_analysis_default_rulesets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_static_analysis_default_rulesets' is not enabled"
@@ -15750,7 +15750,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/default-rulesets/{language}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             language = datadog::urlencode(language)
         );
         let mut local_req_builder =
@@ -15856,9 +15856,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetStaticAnalysisNodeTypesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_static_analysis_node_types";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_static_analysis_node_types";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_static_analysis_node_types' is not enabled".to_string(),
@@ -15870,7 +15870,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/static-analysis-server/node-types/{language}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             language = datadog::urlencode(language)
         );
         let mut local_req_builder =
@@ -15977,9 +15977,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetStaticAnalysisRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_static_analysis_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_static_analysis_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_static_analysis_ruleset' is not enabled".to_string(),
@@ -15995,7 +15995,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/rulesets/{ruleset_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -16107,9 +16107,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetStaticAnalysisTreeSitterWasmError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_static_analysis_tree_sitter_wasm";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_static_analysis_tree_sitter_wasm";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_static_analysis_tree_sitter_wasm' is not enabled"
@@ -16122,7 +16122,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/static-analysis-server/tree-sitter-wasm/{file}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             file = datadog::urlencode(file)
         );
         let mut local_req_builder =
@@ -16223,13 +16223,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSuggestedActionsMatchingSignalError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_suggested_actions_matching_signal";
+        let local_operation_id = "v2.get_suggested_actions_matching_signal";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/{signal_id}/suggested_actions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             signal_id = datadog::urlencode(signal_id)
         );
         let mut local_req_builder =
@@ -16338,7 +16338,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSuppressionVersionHistoryError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_suppression_version_history";
+        let local_operation_id = "v2.get_suppression_version_history";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -16348,7 +16348,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions/{suppression_id}/version_history",
-            local_configuration.get_operation_host(operation_id), suppression_id=
+            local_configuration.get_operation_host(local_operation_id), suppression_id=
             datadog::urlencode(suppression_id)
             );
         let mut local_req_builder =
@@ -16464,13 +16464,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSuppressionsAffectingFutureRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_suppressions_affecting_future_rule";
+        let local_operation_id = "v2.get_suppressions_affecting_future_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions/rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -16623,13 +16623,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetSuppressionsAffectingRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_suppressions_affecting_rule";
+        let local_operation_id = "v2.get_suppressions_affecting_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -16736,13 +16736,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetVulnerabilityNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_vulnerability_notification_rule";
+        let local_operation_id = "v2.get_vulnerability_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerabilities/notification_rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -16846,13 +16846,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<GetVulnerabilityNotificationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_vulnerability_notification_rules";
+        let local_operation_id = "v2.get_vulnerability_notification_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerabilities/notification_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -16974,9 +16974,9 @@ impl SecurityMonitoringAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ImportSecurityVulnerabilitiesError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.import_security_vulnerabilities";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.import_security_vulnerabilities";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.import_security_vulnerabilities' is not enabled".to_string(),
@@ -16988,7 +16988,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerabilities",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -17164,7 +17164,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListAssetsSBOMsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_assets_sbo_ms";
+        let local_operation_id = "v2.list_assets_sbo_ms";
 
         // unbox and build optional parameters
         let page_token = params.page_token;
@@ -17180,7 +17180,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/sboms",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -17431,9 +17431,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListFindingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_findings";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_findings";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_findings' is not enabled".to_string(),
@@ -17462,7 +17462,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/posture_management/findings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -17630,9 +17630,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListHistoricalJobsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_historical_jobs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_historical_jobs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_historical_jobs' is not enabled".to_string(),
@@ -17650,7 +17650,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/jobs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -17772,9 +17772,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListIndicatorsOfCompromiseError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_indicators_of_compromise";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_indicators_of_compromise";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_indicators_of_compromise' is not enabled".to_string(),
@@ -17796,7 +17796,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/siem/ioc-explorer",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -17931,9 +17931,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListMultipleRulesetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_multiple_rulesets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_multiple_rulesets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_multiple_rulesets' is not enabled".to_string(),
@@ -17945,7 +17945,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/rulesets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -18109,9 +18109,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSampleLogGenerationSubscriptionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_sample_log_generation_subscriptions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_sample_log_generation_subscriptions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_sample_log_generation_subscriptions' is not enabled"
@@ -18129,7 +18129,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/sample_log_generation/subscriptions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -18338,9 +18338,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListScannedAssetsMetadataError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_scanned_assets_metadata";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_scanned_assets_metadata";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_scanned_assets_metadata' is not enabled".to_string(),
@@ -18360,7 +18360,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/scanned-assets-metadata",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -18491,13 +18491,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityFilterVersionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_filter_versions";
+        let local_operation_id = "v2.list_security_filter_versions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/security_filters/versions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -18597,13 +18597,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_filters";
+        let local_operation_id = "v2.list_security_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/security_filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -18754,7 +18754,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityFindingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_findings";
+        let local_operation_id = "v2.list_security_findings";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -18766,7 +18766,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -18888,9 +18888,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityFindingsAutomationDueDateRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_findings_automation_due_date_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_security_findings_automation_due_date_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg:
@@ -18908,7 +18908,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/due_date_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -19022,9 +19022,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityFindingsAutomationMuteRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_findings_automation_mute_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_security_findings_automation_mute_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_security_findings_automation_mute_rules' is not enabled"
@@ -19041,7 +19041,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/mute_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -19154,9 +19154,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityFindingsAutomationTicketCreationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_findings_automation_ticket_creation_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_security_findings_automation_ticket_creation_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_security_findings_automation_ticket_creation_rules' is not enabled".to_string(),
@@ -19172,7 +19172,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/ticket_creation_rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -19284,13 +19284,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityMonitoringCriticalAssetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_monitoring_critical_assets";
+        let local_operation_id = "v2.list_security_monitoring_critical_assets";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/critical_assets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -19398,9 +19398,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityMonitoringDatasetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_monitoring_datasets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_security_monitoring_datasets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_security_monitoring_datasets' is not enabled".to_string(),
@@ -19418,7 +19418,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -19541,9 +19541,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityMonitoringHistsignalsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_monitoring_histsignals";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_security_monitoring_histsignals";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_security_monitoring_histsignals' is not enabled"
@@ -19564,7 +19564,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/histsignals",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -19705,9 +19705,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityMonitoringIntegrationConfigsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_monitoring_integration_configs";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_security_monitoring_integration_configs";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_security_monitoring_integration_configs' is not enabled"
@@ -19723,7 +19723,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -19834,7 +19834,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityMonitoringRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_monitoring_rules";
+        let local_operation_id = "v2.list_security_monitoring_rules";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -19846,7 +19846,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -20009,7 +20009,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityMonitoringSignalsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_monitoring_signals";
+        let local_operation_id = "v2.list_security_monitoring_signals";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -20023,7 +20023,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -20160,7 +20160,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListSecurityMonitoringSuppressionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_security_monitoring_suppressions";
+        let local_operation_id = "v2.list_security_monitoring_suppressions";
 
         // unbox and build optional parameters
         let query = params.query;
@@ -20172,7 +20172,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -20293,9 +20293,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListStaticAnalysisCodegenRulesetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_static_analysis_codegen_rulesets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_static_analysis_codegen_rulesets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_static_analysis_codegen_rulesets' is not enabled"
@@ -20308,7 +20308,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/codegen/rulesets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -20586,9 +20586,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListVulnerabilitiesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_vulnerabilities";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_vulnerabilities";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_vulnerabilities' is not enabled".to_string(),
@@ -20648,7 +20648,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerabilities",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -20989,9 +20989,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ListVulnerableAssetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_vulnerable_assets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_vulnerable_assets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_vulnerable_assets' is not enabled".to_string(),
@@ -21023,7 +21023,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerable-assets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -21212,13 +21212,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<MuteSecurityFindingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.mute_security_findings";
+        let local_operation_id = "v2.mute_security_findings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/mute",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -21372,13 +21372,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<PatchSignalNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.patch_signal_notification_rule";
+        let local_operation_id = "v2.patch_signal_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/signals/notification_rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -21533,13 +21533,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<PatchVulnerabilityNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.patch_vulnerability_notification_rule";
+        let local_operation_id = "v2.patch_vulnerability_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/vulnerabilities/notification_rules/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -21692,9 +21692,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ReorderSecurityFindingsAutomationDueDateRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_security_findings_automation_due_date_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.reorder_security_findings_automation_due_date_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.reorder_security_findings_automation_due_date_rules' is not enabled".to_string(),
@@ -21706,7 +21706,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/due_date_rules/reorder",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -21858,9 +21858,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ReorderSecurityFindingsAutomationMuteRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_security_findings_automation_mute_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.reorder_security_findings_automation_mute_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg:
@@ -21874,7 +21874,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/mute_rules/reorder",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -22026,9 +22026,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ReorderSecurityFindingsAutomationTicketCreationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_security_findings_automation_ticket_creation_rules";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.reorder_security_findings_automation_ticket_creation_rules";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.reorder_security_findings_automation_ticket_creation_rules' is not enabled".to_string(),
@@ -22040,7 +22040,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/ticket_creation_rules/reorder",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -22198,9 +22198,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<RestoreSecurityMonitoringRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.restore_security_monitoring_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.restore_security_monitoring_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.restore_security_monitoring_rule' is not enabled".to_string(),
@@ -22212,7 +22212,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/{rule_id}/restore/{version}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id),
             version = version
         );
@@ -22314,9 +22314,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<RunHistoricalJobError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.run_historical_job";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.run_historical_job";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.run_historical_job' is not enabled".to_string(),
@@ -22328,7 +22328,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/jobs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -22534,13 +22534,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<SearchSecurityFindingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_security_findings";
+        let local_operation_id = "v2.search_security_findings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -22692,9 +22692,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<SearchSecurityMonitoringHistsignalsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_security_monitoring_histsignals";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.search_security_monitoring_histsignals";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.search_security_monitoring_histsignals' is not enabled"
@@ -22710,7 +22710,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/siem-historical-detections/histsignals/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -22910,7 +22910,7 @@ impl SecurityMonitoringAPI {
         datadog::Error<SearchSecurityMonitoringSignalsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_security_monitoring_signals";
+        let local_operation_id = "v2.search_security_monitoring_signals";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -22919,7 +22919,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/signals/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -23072,13 +23072,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<SendSecurityMonitoringNotificationPreviewError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.send_security_monitoring_notification_preview";
+        let local_operation_id = "v2.send_security_monitoring_notification_preview";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/notification_rules/send_notification_preview",
-            local_configuration.get_operation_host(operation_id));
+            local_configuration.get_operation_host(local_operation_id));
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
 
@@ -23231,13 +23231,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<TestExistingSecurityMonitoringRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.test_existing_security_monitoring_rule";
+        let local_operation_id = "v2.test_existing_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/{rule_id}/test",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -23390,13 +23390,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<TestSecurityMonitoringRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.test_security_monitoring_rule";
+        let local_operation_id = "v2.test_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/test",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -23552,13 +23552,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateCustomFrameworkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_custom_framework";
+        let local_operation_id = "v2.update_custom_framework";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_security_management/custom_frameworks/{handle}/{version}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             handle = datadog::urlencode(handle),
             version = datadog::urlencode(version)
         );
@@ -23711,9 +23711,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateFindingsAssigneeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_findings_assignee";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_findings_assignee";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_findings_assignee' is not enabled".to_string(),
@@ -23725,7 +23725,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/assignee",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -23876,13 +23876,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateResourceEvaluationFiltersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_resource_evaluation_filters";
+        let local_operation_id = "v2.update_resource_evaluation_filters";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cloud_security_management/resource_filters",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -24039,13 +24039,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityFilterError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_filter";
+        let local_operation_id = "v2.update_security_filter";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/security_filters/{security_filter_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             security_filter_id = datadog::urlencode(security_filter_id)
         );
         let mut local_req_builder =
@@ -24200,9 +24200,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityFindingsAutomationDueDateRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_findings_automation_due_date_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_security_findings_automation_due_date_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_security_findings_automation_due_date_rule' is not enabled".to_string(),
@@ -24214,7 +24214,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/due_date_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -24369,9 +24369,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityFindingsAutomationMuteRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_findings_automation_mute_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_security_findings_automation_mute_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_security_findings_automation_mute_rule' is not enabled"
@@ -24384,7 +24384,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/mute_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -24538,9 +24538,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityFindingsAutomationTicketCreationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_findings_automation_ticket_creation_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_security_findings_automation_ticket_creation_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_security_findings_automation_ticket_creation_rule' is not enabled".to_string(),
@@ -24552,7 +24552,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security/findings/automation/ticket_creation_rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id.to_string())
         );
         let mut local_req_builder =
@@ -24707,13 +24707,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityMonitoringCriticalAssetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_monitoring_critical_asset";
+        let local_operation_id = "v2.update_security_monitoring_critical_asset";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/critical_assets/{critical_asset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             critical_asset_id = datadog::urlencode(critical_asset_id)
         );
         let mut local_req_builder =
@@ -24858,9 +24858,9 @@ impl SecurityMonitoringAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateSecurityMonitoringDatasetError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_monitoring_dataset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_security_monitoring_dataset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_security_monitoring_dataset' is not enabled".to_string(),
@@ -24872,7 +24872,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/datasets/{dataset_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             dataset_id = datadog::urlencode(dataset_id)
         );
         let mut local_req_builder =
@@ -25025,9 +25025,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityMonitoringIntegrationConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_monitoring_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_security_monitoring_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_security_monitoring_integration_config' is not enabled"
@@ -25040,7 +25040,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/{integration_config_id}",
-            local_configuration.get_operation_host(operation_id), integration_config_id=
+            local_configuration.get_operation_host(local_operation_id), integration_config_id=
             datadog::urlencode(integration_config_id)
             );
         let mut local_req_builder =
@@ -25202,13 +25202,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityMonitoringRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_monitoring_rule";
+        let local_operation_id = "v2.update_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -25363,13 +25363,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<UpdateSecurityMonitoringSuppressionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_security_monitoring_suppression";
+        let local_operation_id = "v2.update_security_monitoring_suppression";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions/{suppression_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             suppression_id = datadog::urlencode(suppression_id)
         );
         let mut local_req_builder =
@@ -25514,9 +25514,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ValidateSecurityMonitoringIntegrationConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_security_monitoring_integration_config";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.validate_security_monitoring_integration_config";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg:
@@ -25530,7 +25530,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/{integration_config_id}/validate",
-            local_configuration.get_operation_host(operation_id), integration_config_id=
+            local_configuration.get_operation_host(local_operation_id), integration_config_id=
             datadog::urlencode(integration_config_id)
             );
         let mut local_req_builder =
@@ -25620,9 +25620,9 @@ impl SecurityMonitoringAPI {
         datadog::Error<ValidateSecurityMonitoringIntegrationCredentialsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_security_monitoring_integration_credentials";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.validate_security_monitoring_integration_credentials";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.validate_security_monitoring_integration_credentials' is not enabled".to_string(),
@@ -25634,7 +25634,7 @@ impl SecurityMonitoringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/integration_config/validate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -25766,13 +25766,13 @@ impl SecurityMonitoringAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<ValidateSecurityMonitoringRuleError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_security_monitoring_rule";
+        let local_operation_id = "v2.validate_security_monitoring_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/rules/validation",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -25906,13 +25906,13 @@ impl SecurityMonitoringAPI {
         datadog::Error<ValidateSecurityMonitoringSuppressionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.validate_security_monitoring_suppression";
+        let local_operation_id = "v2.validate_security_monitoring_suppression";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/security_monitoring/configuration/suppressions/validation",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_sensitive_data_scanner.rs
+++ b/src/datadogV2/api/api_sensitive_data_scanner.rs
@@ -195,13 +195,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<CreateScanningGroupError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_scanning_group";
+        let local_operation_id = "v2.create_scanning_group";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config/groups",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -359,13 +359,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<CreateScanningRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_scanning_rule";
+        let local_operation_id = "v2.create_scanning_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config/rules",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -520,13 +520,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<DeleteScanningGroupError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_scanning_group";
+        let local_operation_id = "v2.delete_scanning_group";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config/groups/{group_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             group_id = datadog::urlencode(group_id)
         );
         let mut local_req_builder =
@@ -682,13 +682,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<DeleteScanningRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_scanning_rule";
+        let local_operation_id = "v2.delete_scanning_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =
@@ -837,13 +837,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<ListScanningGroupsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_scanning_groups";
+        let local_operation_id = "v2.list_scanning_groups";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -946,13 +946,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<ListStandardPatternsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_standard_patterns";
+        let local_operation_id = "v2.list_standard_patterns";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config/standard-patterns",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1057,13 +1057,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<ReorderScanningGroupsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.reorder_scanning_groups";
+        let local_operation_id = "v2.reorder_scanning_groups";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -1224,13 +1224,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<UpdateScanningGroupError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_scanning_group";
+        let local_operation_id = "v2.update_scanning_group";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config/groups/{group_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             group_id = datadog::urlencode(group_id)
         );
         let mut local_req_builder =
@@ -1392,13 +1392,13 @@ impl SensitiveDataScannerAPI {
         datadog::Error<UpdateScanningRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_scanning_rule";
+        let local_operation_id = "v2.update_scanning_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/sensitive-data-scanner/config/rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             rule_id = datadog::urlencode(rule_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_service_accounts.rs
+++ b/src/datadogV2/api/api_service_accounts.rs
@@ -297,13 +297,13 @@ impl ServiceAccountsAPI {
         datadog::Error<CreateServiceAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_service_account";
+        let local_operation_id = "v2.create_service_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -455,13 +455,13 @@ impl ServiceAccountsAPI {
         datadog::Error<CreateServiceAccountAccessTokenError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_service_account_access_token";
+        let local_operation_id = "v2.create_service_account_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/access_tokens",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id)
         );
         let mut local_req_builder =
@@ -616,13 +616,13 @@ impl ServiceAccountsAPI {
         datadog::Error<CreateServiceAccountApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_service_account_application_key";
+        let local_operation_id = "v2.create_service_account_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/application_keys",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id)
         );
         let mut local_req_builder =
@@ -764,13 +764,13 @@ impl ServiceAccountsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteServiceAccountApplicationKeyError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_service_account_application_key";
+        let local_operation_id = "v2.delete_service_account_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
@@ -872,13 +872,13 @@ impl ServiceAccountsAPI {
         datadog::Error<GetServiceAccountAccessTokenError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_service_account_access_token";
+        let local_operation_id = "v2.get_service_account_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/access_tokens/{token_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id),
             token_id = datadog::urlencode(token_id)
         );
@@ -987,13 +987,13 @@ impl ServiceAccountsAPI {
         datadog::Error<GetServiceAccountApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_service_account_application_key";
+        let local_operation_id = "v2.get_service_account_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id),
             app_key_id = datadog::urlencode(app_key_id)
         );
@@ -1102,7 +1102,7 @@ impl ServiceAccountsAPI {
         datadog::Error<ListServiceAccountAccessTokensError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_account_access_tokens";
+        let local_operation_id = "v2.list_service_account_access_tokens";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1114,7 +1114,7 @@ impl ServiceAccountsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/access_tokens",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id)
         );
         let mut local_req_builder =
@@ -1239,7 +1239,7 @@ impl ServiceAccountsAPI {
         datadog::Error<ListServiceAccountApplicationKeysError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_account_application_keys";
+        let local_operation_id = "v2.list_service_account_application_keys";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1253,7 +1253,7 @@ impl ServiceAccountsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/application_keys",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id)
         );
         let mut local_req_builder =
@@ -1373,13 +1373,13 @@ impl ServiceAccountsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RevokeServiceAccountAccessTokenError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.revoke_service_account_access_token";
+        let local_operation_id = "v2.revoke_service_account_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/access_tokens/{token_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id),
             token_id = datadog::urlencode(token_id)
         );
@@ -1483,13 +1483,13 @@ impl ServiceAccountsAPI {
         datadog::Error<UpdateServiceAccountAccessTokenError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_service_account_access_token";
+        let local_operation_id = "v2.update_service_account_access_token";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/access_tokens/{token_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id),
             token_id = datadog::urlencode(token_id)
         );
@@ -1651,13 +1651,13 @@ impl ServiceAccountsAPI {
         datadog::Error<UpdateServiceAccountApplicationKeyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_service_account_application_key";
+        let local_operation_id = "v2.update_service_account_application_key";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/service_accounts/{service_account_id}/application_keys/{app_key_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_account_id = datadog::urlencode(service_account_id),
             app_key_id = datadog::urlencode(app_key_id)
         );

--- a/src/datadogV2/api/api_service_definition.rs
+++ b/src/datadogV2/api/api_service_definition.rs
@@ -205,13 +205,13 @@ impl ServiceDefinitionAPI {
         datadog::Error<CreateOrUpdateServiceDefinitionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_or_update_service_definitions";
+        let local_operation_id = "v2.create_or_update_service_definitions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/services/definitions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -349,13 +349,13 @@ impl ServiceDefinitionAPI {
         service_name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteServiceDefinitionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_service_definition";
+        let local_operation_id = "v2.delete_service_definition";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/services/definitions/{service_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_name = datadog::urlencode(service_name)
         );
         let mut local_req_builder =
@@ -456,7 +456,7 @@ impl ServiceDefinitionAPI {
         datadog::Error<GetServiceDefinitionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_service_definition";
+        let local_operation_id = "v2.get_service_definition";
 
         // unbox and build optional parameters
         let schema_version = params.schema_version;
@@ -465,7 +465,7 @@ impl ServiceDefinitionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/services/definitions/{service_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service_name = datadog::urlencode(service_name)
         );
         let mut local_req_builder =
@@ -609,7 +609,7 @@ impl ServiceDefinitionAPI {
         datadog::Error<ListServiceDefinitionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_definitions";
+        let local_operation_id = "v2.list_service_definitions";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -620,7 +620,7 @@ impl ServiceDefinitionAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/services/definitions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_service_level_objectives.rs
+++ b/src/datadogV2/api/api_service_level_objectives.rs
@@ -174,9 +174,9 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<CreateSLOReportJobError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_slo_report_job";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_slo_report_job";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_slo_report_job' is not enabled".to_string(),
@@ -188,7 +188,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/slo/report",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -335,9 +335,9 @@ impl ServiceLevelObjectivesAPI {
         report_id: String,
     ) -> Result<datadog::ResponseContent<String>, datadog::Error<GetSLOReportError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_slo_report";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_slo_report";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_slo_report' is not enabled".to_string(),
@@ -349,7 +349,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/slo/report/{report_id}/download",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             report_id = datadog::urlencode(report_id)
         );
         let mut local_req_builder =
@@ -452,9 +452,9 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<GetSLOReportJobStatusError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_slo_report_job_status";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_slo_report_job_status";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_slo_report_job_status' is not enabled".to_string(),
@@ -466,7 +466,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/slo/report/{report_id}/status",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             report_id = datadog::urlencode(report_id)
         );
         let mut local_req_builder =
@@ -579,9 +579,9 @@ impl ServiceLevelObjectivesAPI {
         datadog::Error<GetSloStatusError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_slo_status";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_slo_status";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_slo_status' is not enabled".to_string(),
@@ -596,7 +596,7 @@ impl ServiceLevelObjectivesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/slo/{slo_id}/status",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             slo_id = datadog::urlencode(slo_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_service_now_integration.rs
+++ b/src/datadogV2/api/api_service_now_integration.rs
@@ -195,13 +195,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<CreateServiceNowTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_service_now_template";
+        let local_operation_id = "v2.create_service_now_template";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -339,13 +339,13 @@ impl ServiceNowIntegrationAPI {
         template_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteServiceNowTemplateError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_service_now_template";
+        let local_operation_id = "v2.delete_service_now_template";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/handles/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id.to_string())
         );
         let mut local_req_builder =
@@ -444,13 +444,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<GetServiceNowTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_service_now_template";
+        let local_operation_id = "v2.get_service_now_template";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/handles/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id.to_string())
         );
         let mut local_req_builder =
@@ -556,13 +556,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<ListServiceNowAssignmentGroupsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_now_assignment_groups";
+        let local_operation_id = "v2.list_service_now_assignment_groups";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/assignment_groups/{instance_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             instance_id = datadog::urlencode(instance_id.to_string())
         );
         let mut local_req_builder =
@@ -668,13 +668,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<ListServiceNowBusinessServicesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_now_business_services";
+        let local_operation_id = "v2.list_service_now_business_services";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/business_services/{instance_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             instance_id = datadog::urlencode(instance_id.to_string())
         );
         let mut local_req_builder =
@@ -775,13 +775,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<ListServiceNowInstancesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_now_instances";
+        let local_operation_id = "v2.list_service_now_instances";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/instances",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -881,13 +881,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<ListServiceNowTemplatesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_now_templates";
+        let local_operation_id = "v2.list_service_now_templates";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/handles",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -992,13 +992,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<ListServiceNowUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_service_now_users";
+        let local_operation_id = "v2.list_service_now_users";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/users/{instance_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             instance_id = datadog::urlencode(instance_id.to_string())
         );
         let mut local_req_builder =
@@ -1106,13 +1106,13 @@ impl ServiceNowIntegrationAPI {
         datadog::Error<UpdateServiceNowTemplateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_service_now_template";
+        let local_operation_id = "v2.update_service_now_template";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/servicenow/handles/{template_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             template_id = datadog::urlencode(template_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_slack_integration.rs
+++ b/src/datadogV2/api/api_slack_integration.rs
@@ -122,13 +122,13 @@ impl SlackIntegrationAPI {
         datadog::Error<ListSlackUserBindingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_slack_user_bindings";
+        let local_operation_id = "v2.list_slack_user_bindings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/slack/user-bindings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_software_catalog.rs
+++ b/src/datadogV2/api/api_software_catalog.rs
@@ -348,13 +348,13 @@ impl SoftwareCatalogAPI {
         entity_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCatalogEntityError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_catalog_entity";
+        let local_operation_id = "v2.delete_catalog_entity";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/entity/{entity_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             entity_id = datadog::urlencode(entity_id)
         );
         let mut local_req_builder =
@@ -436,13 +436,13 @@ impl SoftwareCatalogAPI {
         kind_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCatalogKindError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_catalog_kind";
+        let local_operation_id = "v2.delete_catalog_kind";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/kind/{kind_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             kind_id = datadog::urlencode(kind_id)
         );
         let mut local_req_builder =
@@ -572,7 +572,7 @@ impl SoftwareCatalogAPI {
         datadog::Error<ListCatalogEntityError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_catalog_entity";
+        let local_operation_id = "v2.list_catalog_entity";
 
         // unbox and build optional parameters
         let page_offset = params.page_offset;
@@ -591,7 +591,7 @@ impl SoftwareCatalogAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/entity",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -772,7 +772,7 @@ impl SoftwareCatalogAPI {
         datadog::Error<ListCatalogKindError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_catalog_kind";
+        let local_operation_id = "v2.list_catalog_kind";
 
         // unbox and build optional parameters
         let page_offset = params.page_offset;
@@ -784,7 +784,7 @@ impl SoftwareCatalogAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/kind",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -940,7 +940,7 @@ impl SoftwareCatalogAPI {
         datadog::Error<ListCatalogRelationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_catalog_relation";
+        let local_operation_id = "v2.list_catalog_relation";
 
         // unbox and build optional parameters
         let page_offset = params.page_offset;
@@ -955,7 +955,7 @@ impl SoftwareCatalogAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/relation",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1082,13 +1082,13 @@ impl SoftwareCatalogAPI {
         datadog::Error<PreviewCatalogEntitiesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.preview_catalog_entities";
+        let local_operation_id = "v2.preview_catalog_entities";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/entity/preview",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1190,13 +1190,13 @@ impl SoftwareCatalogAPI {
         datadog::Error<UpsertCatalogEntityError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_catalog_entity";
+        let local_operation_id = "v2.upsert_catalog_entity";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/entity",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1345,13 +1345,13 @@ impl SoftwareCatalogAPI {
         datadog::Error<UpsertCatalogKindError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_catalog_kind";
+        let local_operation_id = "v2.upsert_catalog_kind";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/catalog/kind",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_spa.rs
+++ b/src/datadogV2/api/api_spa.rs
@@ -164,9 +164,9 @@ impl SpaAPI {
         datadog::Error<GetSPARecommendationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_spa_recommendations";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_spa_recommendations";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_spa_recommendations' is not enabled".to_string(),
@@ -181,7 +181,7 @@ impl SpaAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/spa/recommendations/{service}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             service = datadog::urlencode(service)
         );
         let mut local_req_builder =
@@ -282,9 +282,9 @@ impl SpaAPI {
         datadog::Error<GetSPARecommendationsWithShardError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_spa_recommendations_with_shard";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_spa_recommendations_with_shard";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_spa_recommendations_with_shard' is not enabled".to_string(),
@@ -299,7 +299,7 @@ impl SpaAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/spa/recommendations/{service}/{shard}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             shard = datadog::urlencode(shard),
             service = datadog::urlencode(service)
         );

--- a/src/datadogV2/api/api_spans.rs
+++ b/src/datadogV2/api/api_spans.rs
@@ -192,13 +192,13 @@ impl SpansAPI {
         datadog::Error<AggregateSpansError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.aggregate_spans";
+        let local_operation_id = "v2.aggregate_spans";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/spans/analytics/aggregate",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -398,13 +398,13 @@ impl SpansAPI {
         datadog::Error<ListSpansError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_spans";
+        let local_operation_id = "v2.list_spans";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/spans/events/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -593,7 +593,7 @@ impl SpansAPI {
         datadog::Error<ListSpansGetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_spans_get";
+        let local_operation_id = "v2.list_spans_get";
 
         // unbox and build optional parameters
         let filter_query = params.filter_query;
@@ -607,7 +607,7 @@ impl SpansAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/spans/events",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_spans_metrics.rs
+++ b/src/datadogV2/api/api_spans_metrics.rs
@@ -155,13 +155,13 @@ impl SpansMetricsAPI {
         datadog::Error<CreateSpansMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_spans_metric";
+        let local_operation_id = "v2.create_spans_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -296,13 +296,13 @@ impl SpansMetricsAPI {
         metric_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSpansMetricError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_spans_metric";
+        let local_operation_id = "v2.delete_spans_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =
@@ -396,13 +396,13 @@ impl SpansMetricsAPI {
         datadog::Error<GetSpansMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_spans_metric";
+        let local_operation_id = "v2.get_spans_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =
@@ -501,13 +501,13 @@ impl SpansMetricsAPI {
         datadog::Error<ListSpansMetricsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_spans_metrics";
+        let local_operation_id = "v2.list_spans_metrics";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/metrics",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -614,13 +614,13 @@ impl SpansMetricsAPI {
         datadog::Error<UpdateSpansMetricError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_spans_metric";
+        let local_operation_id = "v2.update_spans_metric";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/apm/config/metrics/{metric_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             metric_id = datadog::urlencode(metric_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_static_analysis.rs
+++ b/src/datadogV2/api/api_static_analysis.rs
@@ -476,9 +476,9 @@ impl StaticAnalysisAPI {
         datadog::Error<CreateAiCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_ai_custom_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_ai_custom_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_ai_custom_rule' is not enabled".to_string(),
@@ -490,7 +490,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}/rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -633,9 +633,9 @@ impl StaticAnalysisAPI {
         body: crate::datadogV2::model::AiCustomRuleRevisionRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateAiCustomRuleRevisionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_ai_custom_rule_revision";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_ai_custom_rule_revision";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_ai_custom_rule_revision' is not enabled".to_string(),
@@ -647,7 +647,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}/rules/{rule_name}/revisions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -791,9 +791,9 @@ impl StaticAnalysisAPI {
         datadog::Error<CreateAiCustomRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_ai_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_ai_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_ai_custom_ruleset' is not enabled".to_string(),
@@ -805,7 +805,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -944,9 +944,9 @@ impl StaticAnalysisAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateAiMemoryViolationResultError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_ai_memory_violation_result";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_ai_memory_violation_result";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_ai_memory_violation_result' is not enabled".to_string(),
@@ -958,7 +958,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/memory",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1103,9 +1103,9 @@ impl StaticAnalysisAPI {
         datadog::Error<CreateCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_custom_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_custom_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_custom_rule' is not enabled".to_string(),
@@ -1117,7 +1117,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}/rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -1260,9 +1260,9 @@ impl StaticAnalysisAPI {
         body: crate::datadogV2::model::CustomRuleRevisionRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateCustomRuleRevisionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_custom_rule_revision";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_custom_rule_revision";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_custom_rule_revision' is not enabled".to_string(),
@@ -1274,7 +1274,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}/rules/{rule_name}/revisions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -1418,9 +1418,9 @@ impl StaticAnalysisAPI {
         datadog::Error<CreateCustomRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_custom_ruleset' is not enabled".to_string(),
@@ -1432,7 +1432,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -1582,9 +1582,9 @@ impl StaticAnalysisAPI {
         datadog::Error<CreateSCAResolveVulnerableSymbolsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_sca_resolve_vulnerable_symbols";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_sca_resolve_vulnerable_symbols";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_sca_resolve_vulnerable_symbols' is not enabled"
@@ -1597,7 +1597,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis-sca/vulnerabilities/resolve-vulnerable-symbols",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1730,9 +1730,9 @@ impl StaticAnalysisAPI {
         body: crate::datadogV2::model::ScaRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CreateSCAResultError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_sca_result";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_sca_result";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_sca_result' is not enabled".to_string(),
@@ -1744,7 +1744,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis-sca/dependencies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1882,9 +1882,9 @@ impl StaticAnalysisAPI {
         datadog::Error<CreateSCAScanError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_sca_scan";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_sca_scan";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_sca_scan' is not enabled".to_string(),
@@ -1896,7 +1896,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis-sca/dependencies/scan",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -2036,9 +2036,9 @@ impl StaticAnalysisAPI {
         rule_name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAiCustomRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_ai_custom_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_ai_custom_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_ai_custom_rule' is not enabled".to_string(),
@@ -2050,7 +2050,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}/rules/{rule_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -2136,9 +2136,9 @@ impl StaticAnalysisAPI {
         ruleset_name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAiCustomRulesetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_ai_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_ai_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_ai_custom_ruleset' is not enabled".to_string(),
@@ -2150,7 +2150,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -2236,9 +2236,9 @@ impl StaticAnalysisAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteAiMemoryViolationResultError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_ai_memory_violation_result";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_ai_memory_violation_result";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_ai_memory_violation_result' is not enabled".to_string(),
@@ -2250,7 +2250,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/memory/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -2337,9 +2337,9 @@ impl StaticAnalysisAPI {
         rule_name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCustomRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_custom_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_custom_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_custom_rule' is not enabled".to_string(),
@@ -2351,7 +2351,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}/rules/{rule_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -2437,9 +2437,9 @@ impl StaticAnalysisAPI {
         ruleset_name: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteCustomRulesetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_custom_ruleset' is not enabled".to_string(),
@@ -2451,7 +2451,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -2550,9 +2550,9 @@ impl StaticAnalysisAPI {
         datadog::Error<GetAiCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ai_custom_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_ai_custom_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_ai_custom_rule' is not enabled".to_string(),
@@ -2564,7 +2564,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}/rules/{rule_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -2675,9 +2675,9 @@ impl StaticAnalysisAPI {
         datadog::Error<GetAiCustomRuleRevisionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ai_custom_rule_revision";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_ai_custom_rule_revision";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_ai_custom_rule_revision' is not enabled".to_string(),
@@ -2689,7 +2689,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}/rules/{rule_name}/revisions/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name),
             id = datadog::urlencode(id)
@@ -2797,9 +2797,9 @@ impl StaticAnalysisAPI {
         datadog::Error<GetAiCustomRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_ai_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_ai_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_ai_custom_ruleset' is not enabled".to_string(),
@@ -2811,7 +2811,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -2917,9 +2917,9 @@ impl StaticAnalysisAPI {
         datadog::Error<GetCustomRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_custom_rule";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_custom_rule";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_custom_rule' is not enabled".to_string(),
@@ -2931,7 +2931,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}/rules/{rule_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -3042,9 +3042,9 @@ impl StaticAnalysisAPI {
         datadog::Error<GetCustomRuleRevisionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_custom_rule_revision";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_custom_rule_revision";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_custom_rule_revision' is not enabled".to_string(),
@@ -3056,7 +3056,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}/rules/{rule_name}/revisions/{id}",
-            local_configuration.get_operation_host(operation_id), ruleset_name=
+            local_configuration.get_operation_host(local_operation_id), ruleset_name=
             datadog::urlencode(ruleset_name)
             , rule_name=
             datadog::urlencode(rule_name)
@@ -3161,9 +3161,9 @@ impl StaticAnalysisAPI {
         datadog::Error<GetCustomRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_custom_ruleset' is not enabled".to_string(),
@@ -3175,7 +3175,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -3273,9 +3273,9 @@ impl StaticAnalysisAPI {
         datadog::Error<GetSCAScanError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_sca_scan";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_sca_scan";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_sca_scan' is not enabled".to_string(),
@@ -3287,7 +3287,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis-sca/dependencies/scan/{job_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             job_id = datadog::urlencode(job_id)
         );
         let mut local_req_builder =
@@ -3434,9 +3434,9 @@ impl StaticAnalysisAPI {
         datadog::Error<ListAiCustomRuleRevisionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ai_custom_rule_revisions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_ai_custom_rule_revisions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_ai_custom_rule_revisions' is not enabled".to_string(),
@@ -3452,7 +3452,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}/rules/{rule_name}/revisions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -3565,9 +3565,9 @@ impl StaticAnalysisAPI {
         datadog::Error<ListAiCustomRulesetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ai_custom_rulesets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_ai_custom_rulesets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_ai_custom_rulesets' is not enabled".to_string(),
@@ -3583,7 +3583,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3692,9 +3692,9 @@ impl StaticAnalysisAPI {
         datadog::Error<ListAiMemoryViolationResultsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ai_memory_violation_results";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_ai_memory_violation_results";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_ai_memory_violation_results' is not enabled".to_string(),
@@ -3706,7 +3706,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/memory",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3804,9 +3804,9 @@ impl StaticAnalysisAPI {
         datadog::Error<ListAiPromptsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_ai_prompts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_ai_prompts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_ai_prompts' is not enabled".to_string(),
@@ -3818,7 +3818,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/prompts",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3965,9 +3965,9 @@ impl StaticAnalysisAPI {
         datadog::Error<ListCustomRuleRevisionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_custom_rule_revisions";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_custom_rule_revisions";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_custom_rule_revisions' is not enabled".to_string(),
@@ -3983,7 +3983,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}/rules/{rule_name}/revisions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name),
             rule_name = datadog::urlencode(rule_name)
         );
@@ -4094,9 +4094,9 @@ impl StaticAnalysisAPI {
         datadog::Error<ListCustomRulesetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_custom_rulesets";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_custom_rulesets";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_custom_rulesets' is not enabled".to_string(),
@@ -4108,7 +4108,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4204,9 +4204,9 @@ impl StaticAnalysisAPI {
         datadog::Error<ListSCALicensesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_sca_licenses";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_sca_licenses";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_sca_licenses' is not enabled".to_string(),
@@ -4218,7 +4218,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis-sca/licenses/list",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4313,9 +4313,9 @@ impl StaticAnalysisAPI {
         body: crate::datadogV2::model::RevertCustomRuleRevisionRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RevertCustomRuleRevisionError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.revert_custom_rule_revision";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.revert_custom_rule_revision";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.revert_custom_rule_revision' is not enabled".to_string(),
@@ -4327,7 +4327,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}/rules/{rule_name}/revisions/revert",
-            local_configuration.get_operation_host(operation_id), ruleset_name=
+            local_configuration.get_operation_host(local_operation_id), ruleset_name=
             datadog::urlencode(ruleset_name)
             , rule_name=
             datadog::urlencode(rule_name)
@@ -4463,9 +4463,9 @@ impl StaticAnalysisAPI {
         body: crate::datadogV2::model::AiCustomRulesetUpdateRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateAiCustomRulesetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_ai_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_ai_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_ai_custom_ruleset' is not enabled".to_string(),
@@ -4477,7 +4477,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/ai/rulesets/{ruleset_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =
@@ -4625,9 +4625,9 @@ impl StaticAnalysisAPI {
         datadog::Error<UpdateCustomRulesetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_custom_ruleset";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_custom_ruleset";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_custom_ruleset' is not enabled".to_string(),
@@ -4639,7 +4639,7 @@ impl StaticAnalysisAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/static-analysis/custom/rulesets/{ruleset_name}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             ruleset_name = datadog::urlencode(ruleset_name)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_status_pages.rs
+++ b/src/datadogV2/api/api_status_pages.rs
@@ -752,7 +752,7 @@ impl StatusPagesAPI {
         datadog::Error<CreateBackfilledDegradationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_backfilled_degradation";
+        let local_operation_id = "v2.create_backfilled_degradation";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -761,7 +761,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/degradations/backfill",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -921,7 +921,7 @@ impl StatusPagesAPI {
         datadog::Error<CreateBackfilledMaintenanceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_backfilled_maintenance";
+        let local_operation_id = "v2.create_backfilled_maintenance";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -930,7 +930,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/maintenances/backfill",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -1088,7 +1088,7 @@ impl StatusPagesAPI {
         datadog::Error<CreateComponentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_component";
+        let local_operation_id = "v2.create_component";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1097,7 +1097,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/components",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -1256,7 +1256,7 @@ impl StatusPagesAPI {
         datadog::Error<CreateDegradationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_degradation";
+        let local_operation_id = "v2.create_degradation";
 
         // unbox and build optional parameters
         let notify_subscribers = params.notify_subscribers;
@@ -1266,7 +1266,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/degradations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -1427,7 +1427,7 @@ impl StatusPagesAPI {
         datadog::Error<CreateMaintenanceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_maintenance";
+        let local_operation_id = "v2.create_maintenance";
 
         // unbox and build optional parameters
         let notify_subscribers = params.notify_subscribers;
@@ -1437,7 +1437,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/maintenances",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -1593,7 +1593,7 @@ impl StatusPagesAPI {
         datadog::Error<CreateStatusPageError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_status_page";
+        let local_operation_id = "v2.create_status_page";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -1602,7 +1602,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1745,13 +1745,13 @@ impl StatusPagesAPI {
         component_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteComponentError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_component";
+        let local_operation_id = "v2.delete_component";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/components/{component_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             component_id = datadog::urlencode(component_id.to_string())
         );
@@ -1839,13 +1839,13 @@ impl StatusPagesAPI {
         degradation_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteDegradationError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_degradation";
+        let local_operation_id = "v2.delete_degradation";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/degradations/{degradation_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             degradation_id = datadog::urlencode(degradation_id.to_string())
         );
@@ -1928,13 +1928,13 @@ impl StatusPagesAPI {
         page_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteStatusPageError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_status_page";
+        let local_operation_id = "v2.delete_status_page";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -2047,7 +2047,7 @@ impl StatusPagesAPI {
         datadog::Error<EditDegradationUpdateError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.edit_degradation_update";
+        let local_operation_id = "v2.edit_degradation_update";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2056,7 +2056,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/degradations/{degradation_id}/updates/{update_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             degradation_id = datadog::urlencode(degradation_id.to_string()),
             page_id = datadog::urlencode(page_id.to_string()),
             update_id = datadog::urlencode(update_id.to_string())
@@ -2217,7 +2217,7 @@ impl StatusPagesAPI {
         datadog::Error<GetComponentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_component";
+        let local_operation_id = "v2.get_component";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2226,7 +2226,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/components/{component_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             component_id = datadog::urlencode(component_id.to_string())
         );
@@ -2338,7 +2338,7 @@ impl StatusPagesAPI {
         datadog::Error<GetDegradationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_degradation";
+        let local_operation_id = "v2.get_degradation";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2347,7 +2347,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/degradations/{degradation_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             degradation_id = datadog::urlencode(degradation_id.to_string())
         );
@@ -2458,7 +2458,7 @@ impl StatusPagesAPI {
         datadog::Error<GetMaintenanceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_maintenance";
+        let local_operation_id = "v2.get_maintenance";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2467,7 +2467,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/maintenances/{maintenance_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             maintenance_id = datadog::urlencode(maintenance_id.to_string())
         );
@@ -2573,7 +2573,7 @@ impl StatusPagesAPI {
         datadog::Error<GetStatusPageError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_status_page";
+        let local_operation_id = "v2.get_status_page";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2582,7 +2582,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -2690,7 +2690,7 @@ impl StatusPagesAPI {
         datadog::Error<ListComponentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_components";
+        let local_operation_id = "v2.list_components";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -2699,7 +2699,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/components",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -2805,7 +2805,7 @@ impl StatusPagesAPI {
         datadog::Error<ListDegradationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_degradations";
+        let local_operation_id = "v2.list_degradations";
 
         // unbox and build optional parameters
         let filter_page_id = params.filter_page_id;
@@ -2819,7 +2819,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/degradations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2943,7 +2943,7 @@ impl StatusPagesAPI {
         datadog::Error<ListMaintenancesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_maintenances";
+        let local_operation_id = "v2.list_maintenances";
 
         // unbox and build optional parameters
         let filter_page_id = params.filter_page_id;
@@ -2957,7 +2957,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/maintenances",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3081,7 +3081,7 @@ impl StatusPagesAPI {
         datadog::Error<ListStatusPagesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_status_pages";
+        let local_operation_id = "v2.list_status_pages";
 
         // unbox and build optional parameters
         let page_offset = params.page_offset;
@@ -3093,7 +3093,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3196,13 +3196,13 @@ impl StatusPagesAPI {
         page_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<PublishStatusPageError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.publish_status_page";
+        let local_operation_id = "v2.publish_status_page";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/publish",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -3292,13 +3292,13 @@ impl StatusPagesAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<SoftDeleteDegradationUpdateError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.soft_delete_degradation_update";
+        let local_operation_id = "v2.soft_delete_degradation_update";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/degradations/{degradation_id}/updates/{update_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             degradation_id = datadog::urlencode(degradation_id.to_string()),
             page_id = datadog::urlencode(page_id.to_string()),
             update_id = datadog::urlencode(update_id.to_string())
@@ -3382,13 +3382,13 @@ impl StatusPagesAPI {
         page_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UnpublishStatusPageError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.unpublish_status_page";
+        let local_operation_id = "v2.unpublish_status_page";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/unpublish",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =
@@ -3491,7 +3491,7 @@ impl StatusPagesAPI {
         datadog::Error<UpdateComponentError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_component";
+        let local_operation_id = "v2.update_component";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -3500,7 +3500,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/components/{component_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             component_id = datadog::urlencode(component_id.to_string())
         );
@@ -3662,7 +3662,7 @@ impl StatusPagesAPI {
         datadog::Error<UpdateDegradationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_degradation";
+        let local_operation_id = "v2.update_degradation";
 
         // unbox and build optional parameters
         let notify_subscribers = params.notify_subscribers;
@@ -3672,7 +3672,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/degradations/{degradation_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             degradation_id = datadog::urlencode(degradation_id.to_string())
         );
@@ -3836,7 +3836,7 @@ impl StatusPagesAPI {
         datadog::Error<UpdateMaintenanceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_maintenance";
+        let local_operation_id = "v2.update_maintenance";
 
         // unbox and build optional parameters
         let notify_subscribers = params.notify_subscribers;
@@ -3846,7 +3846,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}/maintenances/{maintenance_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string()),
             maintenance_id = datadog::urlencode(maintenance_id.to_string())
         );
@@ -4008,7 +4008,7 @@ impl StatusPagesAPI {
         datadog::Error<UpdateStatusPageError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_status_page";
+        let local_operation_id = "v2.update_status_page";
 
         // unbox and build optional parameters
         let delete_subscribers = params.delete_subscribers;
@@ -4018,7 +4018,7 @@ impl StatusPagesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/statuspages/{page_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             page_id = datadog::urlencode(page_id.to_string())
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_statuspage_integration.rs
+++ b/src/datadogV2/api/api_statuspage_integration.rs
@@ -182,13 +182,13 @@ impl StatuspageIntegrationAPI {
         datadog::Error<CreateStatuspageAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_statuspage_account";
+        let local_operation_id = "v2.create_statuspage_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/account",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -340,13 +340,13 @@ impl StatuspageIntegrationAPI {
         datadog::Error<CreateStatuspageUrlSettingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_statuspage_url_setting";
+        let local_operation_id = "v2.create_statuspage_url_setting";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/url_settings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -479,13 +479,13 @@ impl StatuspageIntegrationAPI {
         &self,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteStatuspageAccountError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_statuspage_account";
+        let local_operation_id = "v2.delete_statuspage_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/account",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -569,13 +569,13 @@ impl StatuspageIntegrationAPI {
         statuspage_url_setting_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteStatuspageUrlSettingError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_statuspage_url_setting";
+        let local_operation_id = "v2.delete_statuspage_url_setting";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/url_settings/{statuspage_url_setting_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             statuspage_url_setting_id = datadog::urlencode(statuspage_url_setting_id)
         );
         let mut local_req_builder =
@@ -669,13 +669,13 @@ impl StatuspageIntegrationAPI {
         datadog::Error<GetStatuspageAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_statuspage_account";
+        let local_operation_id = "v2.get_statuspage_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/account",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -775,13 +775,13 @@ impl StatuspageIntegrationAPI {
         datadog::Error<ListStatuspageUrlSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_statuspage_url_settings";
+        let local_operation_id = "v2.list_statuspage_url_settings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/url_settings",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -883,13 +883,13 @@ impl StatuspageIntegrationAPI {
         datadog::Error<UpdateStatuspageAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_statuspage_account";
+        let local_operation_id = "v2.update_statuspage_account";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/account",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -1043,13 +1043,13 @@ impl StatuspageIntegrationAPI {
         datadog::Error<UpdateStatuspageUrlSettingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_statuspage_url_setting";
+        let local_operation_id = "v2.update_statuspage_url_setting";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/statuspage/url_settings/{statuspage_url_setting_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             statuspage_url_setting_id = datadog::urlencode(statuspage_url_setting_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_stegadography.rs
+++ b/src/datadogV2/api/api_stegadography.rs
@@ -125,13 +125,13 @@ impl StegadographyAPI {
         datadog::Error<GetStegadographyWidgetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_stegadography_widgets";
+        let local_operation_id = "v2.get_stegadography_widgets";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/stegadography/get-widgets",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());

--- a/src/datadogV2/api/api_storage_management.rs
+++ b/src/datadogV2/api/api_storage_management.rs
@@ -119,13 +119,13 @@ impl StorageManagementAPI {
         id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSyncConfigError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_sync_config";
+        let local_operation_id = "v2.delete_sync_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cloudinventoryservice/syncconfigs/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -221,13 +221,13 @@ impl StorageManagementAPI {
         datadog::Error<UpsertSyncConfigError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.upsert_sync_config";
+        let local_operation_id = "v2.upsert_sync_config";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cloudinventoryservice/syncconfigs",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());

--- a/src/datadogV2/api/api_synthetics.rs
+++ b/src/datadogV2/api/api_synthetics.rs
@@ -665,13 +665,13 @@ impl SyntheticsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<AbortTestFileMultipartUploadError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.abort_test_file_multipart_upload";
+        let local_operation_id = "v2.abort_test_file_multipart_upload";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/files/multipart-upload-abort",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -819,13 +819,13 @@ impl SyntheticsAPI {
         datadog::Error<AddTestToSyntheticsDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_test_to_synthetics_downtime";
+        let local_operation_id = "v2.add_test_to_synthetics_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/downtimes/{downtime_id}/tests/{test_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id),
             test_id = datadog::urlencode(test_id)
         );
@@ -923,13 +923,13 @@ impl SyntheticsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<CompleteTestFileMultipartUploadError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.complete_test_file_multipart_upload";
+        let local_operation_id = "v2.complete_test_file_multipart_upload";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/files/multipart-upload-complete",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -1072,13 +1072,13 @@ impl SyntheticsAPI {
         datadog::Error<CreateSyntheticsDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_synthetics_downtime";
+        let local_operation_id = "v2.create_synthetics_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/downtimes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1228,13 +1228,13 @@ impl SyntheticsAPI {
         datadog::Error<CreateSyntheticsNetworkTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_synthetics_network_test";
+        let local_operation_id = "v2.create_synthetics_network_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/network",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1381,13 +1381,13 @@ impl SyntheticsAPI {
         datadog::Error<CreateSyntheticsSuiteError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_synthetics_suite";
+        let local_operation_id = "v2.create_synthetics_suite";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/suites",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1525,13 +1525,13 @@ impl SyntheticsAPI {
         downtime_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteSyntheticsDowntimeError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_synthetics_downtime";
+        let local_operation_id = "v2.delete_synthetics_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/downtimes/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id)
         );
         let mut local_req_builder =
@@ -1625,13 +1625,13 @@ impl SyntheticsAPI {
         datadog::Error<DeleteSyntheticsSuitesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_synthetics_suites";
+        let local_operation_id = "v2.delete_synthetics_suites";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/suites/bulk-delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1778,13 +1778,13 @@ impl SyntheticsAPI {
         datadog::Error<DeleteSyntheticsTestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_synthetics_tests";
+        let local_operation_id = "v2.delete_synthetics_tests";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/bulk-delete",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1936,13 +1936,13 @@ impl SyntheticsAPI {
         datadog::Error<EditSyntheticsSuiteError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.edit_synthetics_suite";
+        let local_operation_id = "v2.edit_synthetics_suite";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/suites/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2099,13 +2099,13 @@ impl SyntheticsAPI {
         datadog::Error<GetApiMultistepSubtestParentsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_api_multistep_subtest_parents";
+        let local_operation_id = "v2.get_api_multistep_subtest_parents";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/api-multistep/subtests/{public_id}/parents",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2214,13 +2214,13 @@ impl SyntheticsAPI {
         datadog::Error<GetApiMultistepSubtestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_api_multistep_subtests";
+        let local_operation_id = "v2.get_api_multistep_subtests";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/api-multistep/subtests/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2322,13 +2322,13 @@ impl SyntheticsAPI {
         datadog::Error<GetOnDemandConcurrencyCapError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_on_demand_concurrency_cap";
+        let local_operation_id = "v2.get_on_demand_concurrency_cap";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/settings/on_demand_concurrency_cap",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2437,7 +2437,7 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsBrowserTestResultError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_synthetics_browser_test_result";
+        let local_operation_id = "v2.get_synthetics_browser_test_result";
 
         // unbox and build optional parameters
         let event_id = params.event_id;
@@ -2447,7 +2447,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/browser/{public_id}/results/{result_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id),
             result_id = datadog::urlencode(result_id)
         );
@@ -2563,13 +2563,13 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_synthetics_downtime";
+        let local_operation_id = "v2.get_synthetics_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/downtimes/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id)
         );
         let mut local_req_builder =
@@ -2673,13 +2673,13 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsFastTestResultError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_synthetics_fast_test_result";
+        let local_operation_id = "v2.get_synthetics_fast_test_result";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/fast/{id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             id = datadog::urlencode(id)
         );
         let mut local_req_builder =
@@ -2783,13 +2783,13 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsNetworkTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_synthetics_network_test";
+        let local_operation_id = "v2.get_synthetics_network_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/network/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -2890,13 +2890,13 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsSuiteError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_synthetics_suite";
+        let local_operation_id = "v2.get_synthetics_suite";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/suites/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -3006,7 +3006,7 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsTestResultError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_synthetics_test_result";
+        let local_operation_id = "v2.get_synthetics_test_result";
 
         // unbox and build optional parameters
         let event_id = params.event_id;
@@ -3016,7 +3016,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/results/{result_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id),
             result_id = datadog::urlencode(result_id)
         );
@@ -3136,7 +3136,7 @@ impl SyntheticsAPI {
         datadog::Error<GetSyntheticsTestVersionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_synthetics_test_version";
+        let local_operation_id = "v2.get_synthetics_test_version";
 
         // unbox and build optional parameters
         let include_change_metadata = params.include_change_metadata;
@@ -3146,7 +3146,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/version_history/{version_number}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id),
             version_number = version_number
         );
@@ -3266,13 +3266,13 @@ impl SyntheticsAPI {
         datadog::Error<GetTestFileDownloadUrlError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_test_file_download_url";
+        let local_operation_id = "v2.get_test_file_download_url";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/files/download",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -3431,13 +3431,13 @@ impl SyntheticsAPI {
         datadog::Error<GetTestFileMultipartPresignedUrlsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_test_file_multipart_presigned_urls";
+        let local_operation_id = "v2.get_test_file_multipart_presigned_urls";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/files/multipart-presigned-urls",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -3588,13 +3588,13 @@ impl SyntheticsAPI {
         datadog::Error<GetTestParentSuitesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_test_parent_suites";
+        let local_operation_id = "v2.get_test_parent_suites";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/parent-suites",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -3702,7 +3702,7 @@ impl SyntheticsAPI {
         datadog::Error<ListSyntheticsBrowserTestLatestResultsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_synthetics_browser_test_latest_results";
+        let local_operation_id = "v2.list_synthetics_browser_test_latest_results";
 
         // unbox and build optional parameters
         let from_ts = params.from_ts;
@@ -3716,7 +3716,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/browser/{public_id}/results",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -3846,7 +3846,7 @@ impl SyntheticsAPI {
         datadog::Error<ListSyntheticsDowntimesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_synthetics_downtimes";
+        let local_operation_id = "v2.list_synthetics_downtimes";
 
         // unbox and build optional parameters
         let filter_test_ids = params.filter_test_ids;
@@ -3856,7 +3856,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/downtimes",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3972,7 +3972,7 @@ impl SyntheticsAPI {
         datadog::Error<ListSyntheticsTestLatestResultsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_synthetics_test_latest_results";
+        let local_operation_id = "v2.list_synthetics_test_latest_results";
 
         // unbox and build optional parameters
         let from_ts = params.from_ts;
@@ -3986,7 +3986,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/results",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -4121,7 +4121,7 @@ impl SyntheticsAPI {
         datadog::Error<ListSyntheticsTestVersionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_synthetics_test_versions";
+        let local_operation_id = "v2.list_synthetics_test_versions";
 
         // unbox and build optional parameters
         let last_version_number = params.last_version_number;
@@ -4131,7 +4131,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/{public_id}/version_history",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -4263,13 +4263,13 @@ impl SyntheticsAPI {
         datadog::Error<PatchGlobalVariableError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.patch_global_variable";
+        let local_operation_id = "v2.patch_global_variable";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/variables/{variable_id}/jsonpatch",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             variable_id = datadog::urlencode(variable_id)
         );
         let mut local_req_builder =
@@ -4431,13 +4431,13 @@ impl SyntheticsAPI {
         datadog::Error<PatchTestSuiteError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.patch_test_suite";
+        let local_operation_id = "v2.patch_test_suite";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/suites/{public_id}/jsonpatch",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =
@@ -4592,13 +4592,13 @@ impl SyntheticsAPI {
         datadog::Error<PollSyntheticsTestResultsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.poll_synthetics_test_results";
+        let local_operation_id = "v2.poll_synthetics_test_results";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/poll_results",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4707,13 +4707,13 @@ impl SyntheticsAPI {
         datadog::Error<RemoveTestFromSyntheticsDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_test_from_synthetics_downtime";
+        let local_operation_id = "v2.remove_test_from_synthetics_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/downtimes/{downtime_id}/tests/{test_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id),
             test_id = datadog::urlencode(test_id)
         );
@@ -4817,7 +4817,7 @@ impl SyntheticsAPI {
         datadog::Error<SearchSuitesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_suites";
+        let local_operation_id = "v2.search_suites";
 
         // unbox and build optional parameters
         let query = params.query;
@@ -4830,7 +4830,7 @@ impl SyntheticsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/suites/search",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4955,13 +4955,13 @@ impl SyntheticsAPI {
         datadog::Error<SetOnDemandConcurrencyCapError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.set_on_demand_concurrency_cap";
+        let local_operation_id = "v2.set_on_demand_concurrency_cap";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/settings/on_demand_concurrency_cap",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -5115,13 +5115,13 @@ impl SyntheticsAPI {
         datadog::Error<UpdateSyntheticsDowntimeError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_synthetics_downtime";
+        let local_operation_id = "v2.update_synthetics_downtime";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/downtimes/{downtime_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             downtime_id = datadog::urlencode(downtime_id)
         );
         let mut local_req_builder =
@@ -5274,13 +5274,13 @@ impl SyntheticsAPI {
         datadog::Error<UpdateSyntheticsNetworkTestError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_synthetics_network_test";
+        let local_operation_id = "v2.update_synthetics_network_test";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/synthetics/tests/network/{public_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             public_id = datadog::urlencode(public_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_tag_policies.rs
+++ b/src/datadogV2/api/api_tag_policies.rs
@@ -296,9 +296,9 @@ impl TagPoliciesAPI {
         datadog::Error<CreateTagPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_tag_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_tag_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_tag_policy' is not enabled".to_string(),
@@ -310,7 +310,7 @@ impl TagPoliciesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/tag-policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -453,9 +453,9 @@ impl TagPoliciesAPI {
         params: DeleteTagPolicyOptionalParams,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTagPolicyError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_tag_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_tag_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_tag_policy' is not enabled".to_string(),
@@ -470,7 +470,7 @@ impl TagPoliciesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/tag-policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -574,9 +574,9 @@ impl TagPoliciesAPI {
         datadog::Error<GetTagPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tag_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_tag_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_tag_policy' is not enabled".to_string(),
@@ -593,7 +593,7 @@ impl TagPoliciesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/tag-policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -718,9 +718,9 @@ impl TagPoliciesAPI {
         datadog::Error<GetTagPolicyScoreError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_tag_policy_score";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_tag_policy_score";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_tag_policy_score' is not enabled".to_string(),
@@ -736,7 +736,7 @@ impl TagPoliciesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/tag-policies/{policy_id}/score",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =
@@ -852,9 +852,9 @@ impl TagPoliciesAPI {
         datadog::Error<ListTagPoliciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_tag_policies";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_tag_policies";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_tag_policies' is not enabled".to_string(),
@@ -874,7 +874,7 @@ impl TagPoliciesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/tag-policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1005,9 +1005,9 @@ impl TagPoliciesAPI {
         datadog::Error<UpdateTagPolicyError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_tag_policy";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_tag_policy";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_tag_policy' is not enabled".to_string(),
@@ -1019,7 +1019,7 @@ impl TagPoliciesAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/tag-policies/{policy_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             policy_id = datadog::urlencode(policy_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_teams.rs
+++ b/src/datadogV2/api/api_teams.rs
@@ -600,9 +600,9 @@ impl TeamsAPI {
         body: crate::datadogV2::model::AddMemberTeamRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<AddMemberTeamError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_member_team";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.add_member_team";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.add_member_team' is not enabled".to_string(),
@@ -614,7 +614,7 @@ impl TeamsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/team/{super_team_id}/member_teams",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             super_team_id = datadog::urlencode(super_team_id)
         );
         let mut local_req_builder =
@@ -757,13 +757,13 @@ impl TeamsAPI {
         datadog::Error<AddTeamHierarchyLinkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.add_team_hierarchy_link";
+        let local_operation_id = "v2.add_team_hierarchy_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team-hierarchy-links",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -911,13 +911,13 @@ impl TeamsAPI {
         datadog::Error<CreateTeamError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_team";
+        let local_operation_id = "v2.create_team";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1063,13 +1063,13 @@ impl TeamsAPI {
         datadog::Error<CreateTeamConnectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_team_connections";
+        let local_operation_id = "v2.create_team_connections";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/connections",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1218,13 +1218,13 @@ impl TeamsAPI {
         datadog::Error<CreateTeamLinkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_team_link";
+        let local_operation_id = "v2.create_team_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/links",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -1380,13 +1380,13 @@ impl TeamsAPI {
         datadog::Error<CreateTeamMembershipError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_team_membership";
+        let local_operation_id = "v2.create_team_membership";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/memberships",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -1538,13 +1538,13 @@ impl TeamsAPI {
         datadog::Error<CreateTeamNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_team_notification_rule";
+        let local_operation_id = "v2.create_team_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/notification-rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -1680,13 +1680,13 @@ impl TeamsAPI {
         team_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTeamError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_team";
+        let local_operation_id = "v2.delete_team";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -1767,13 +1767,13 @@ impl TeamsAPI {
         body: crate::datadogV2::model::TeamConnectionDeleteRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTeamConnectionsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_team_connections";
+        let local_operation_id = "v2.delete_team_connections";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/connections",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -1903,13 +1903,13 @@ impl TeamsAPI {
         link_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTeamLinkError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_team_link";
+        let local_operation_id = "v2.delete_team_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/links/{link_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             link_id = datadog::urlencode(link_id)
         );
@@ -2001,13 +2001,13 @@ impl TeamsAPI {
         user_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTeamMembershipError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_team_membership";
+        let local_operation_id = "v2.delete_team_membership";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/memberships/{user_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             user_id = datadog::urlencode(user_id)
         );
@@ -2093,13 +2093,13 @@ impl TeamsAPI {
         rule_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteTeamNotificationRuleError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_team_notification_rule";
+        let local_operation_id = "v2.delete_team_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/notification-rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -2193,13 +2193,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team";
+        let local_operation_id = "v2.get_team";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -2299,13 +2299,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamHierarchyLinkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_hierarchy_link";
+        let local_operation_id = "v2.get_team_hierarchy_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team-hierarchy-links/{link_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             link_id = datadog::urlencode(link_id)
         );
         let mut local_req_builder =
@@ -2407,13 +2407,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamLinkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_link";
+        let local_operation_id = "v2.get_team_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/links/{link_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             link_id = datadog::urlencode(link_id)
         );
@@ -2512,13 +2512,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamLinksError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_links";
+        let local_operation_id = "v2.get_team_links";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/links",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -2656,7 +2656,7 @@ impl TeamsAPI {
         datadog::Error<GetTeamMembershipsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_memberships";
+        let local_operation_id = "v2.get_team_memberships";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -2668,7 +2668,7 @@ impl TeamsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/memberships",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -2790,13 +2790,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_notification_rule";
+        let local_operation_id = "v2.get_team_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/notification-rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -2901,13 +2901,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamNotificationRulesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_notification_rules";
+        let local_operation_id = "v2.get_team_notification_rules";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/notification-rules",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -3013,13 +3013,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamPermissionSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_permission_settings";
+        let local_operation_id = "v2.get_team_permission_settings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/permission-settings",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -3121,13 +3121,13 @@ impl TeamsAPI {
         datadog::Error<GetTeamSyncError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_team_sync";
+        let local_operation_id = "v2.get_team_sync";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/sync",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3228,13 +3228,13 @@ impl TeamsAPI {
         datadog::Error<GetUserMembershipsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_user_memberships";
+        let local_operation_id = "v2.get_user_memberships";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_uuid}/memberships",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_uuid = datadog::urlencode(user_uuid)
         );
         let mut local_req_builder =
@@ -3378,9 +3378,9 @@ impl TeamsAPI {
         datadog::Error<ListMemberTeamsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_member_teams";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_member_teams";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_member_teams' is not enabled".to_string(),
@@ -3397,7 +3397,7 @@ impl TeamsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/team/{super_team_id}/member_teams",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             super_team_id = datadog::urlencode(super_team_id)
         );
         let mut local_req_builder =
@@ -3554,7 +3554,7 @@ impl TeamsAPI {
         datadog::Error<ListTeamConnectionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_team_connections";
+        let local_operation_id = "v2.list_team_connections";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -3568,7 +3568,7 @@ impl TeamsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/team/connections",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3759,7 +3759,7 @@ impl TeamsAPI {
         datadog::Error<ListTeamHierarchyLinksError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_team_hierarchy_links";
+        let local_operation_id = "v2.list_team_hierarchy_links";
 
         // unbox and build optional parameters
         let page_number = params.page_number;
@@ -3771,7 +3771,7 @@ impl TeamsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/team-hierarchy-links",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -3921,7 +3921,7 @@ impl TeamsAPI {
         datadog::Error<ListTeamsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_teams";
+        let local_operation_id = "v2.list_teams";
 
         // unbox and build optional parameters
         let page_number = params.page_number;
@@ -3936,7 +3936,7 @@ impl TeamsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/team",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -4067,9 +4067,9 @@ impl TeamsAPI {
         member_team_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RemoveMemberTeamError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_member_team";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.remove_member_team";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.remove_member_team' is not enabled".to_string(),
@@ -4081,7 +4081,7 @@ impl TeamsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/team/{super_team_id}/member_teams/{member_team_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             super_team_id = datadog::urlencode(super_team_id),
             member_team_id = datadog::urlencode(member_team_id)
         );
@@ -4167,13 +4167,13 @@ impl TeamsAPI {
         link_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<RemoveTeamHierarchyLinkError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.remove_team_hierarchy_link";
+        let local_operation_id = "v2.remove_team_hierarchy_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team-hierarchy-links/{link_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             link_id = datadog::urlencode(link_id)
         );
         let mut local_req_builder =
@@ -4283,13 +4283,13 @@ impl TeamsAPI {
         body: crate::datadogV2::model::TeamSyncRequest,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<SyncTeamsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.sync_teams";
+        let local_operation_id = "v2.sync_teams";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/sync",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -4431,13 +4431,13 @@ impl TeamsAPI {
         datadog::Error<UpdateTeamError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_team";
+        let local_operation_id = "v2.update_team";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id)
         );
         let mut local_req_builder =
@@ -4589,13 +4589,13 @@ impl TeamsAPI {
         datadog::Error<UpdateTeamLinkError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_team_link";
+        let local_operation_id = "v2.update_team_link";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/links/{link_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             link_id = datadog::urlencode(link_id)
         );
@@ -4754,13 +4754,13 @@ impl TeamsAPI {
         datadog::Error<UpdateTeamMembershipError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_team_membership";
+        let local_operation_id = "v2.update_team_membership";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/memberships/{user_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             user_id = datadog::urlencode(user_id)
         );
@@ -4915,13 +4915,13 @@ impl TeamsAPI {
         datadog::Error<UpdateTeamNotificationRuleError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_team_notification_rule";
+        let local_operation_id = "v2.update_team_notification_rule";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/notification-rules/{rule_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             rule_id = datadog::urlencode(rule_id)
         );
@@ -5079,13 +5079,13 @@ impl TeamsAPI {
         datadog::Error<UpdateTeamPermissionSettingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_team_permission_setting";
+        let local_operation_id = "v2.update_team_permission_setting";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/team/{team_id}/permission-settings/{action}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             team_id = datadog::urlencode(team_id),
             action = datadog::urlencode(action)
         );

--- a/src/datadogV2/api/api_test_optimization.rs
+++ b/src/datadogV2/api/api_test_optimization.rs
@@ -179,13 +179,13 @@ impl TestOptimizationAPI {
         datadog::Error<DeleteTestOptimizationServiceSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_test_optimization_service_settings";
+        let local_operation_id = "v2.delete_test_optimization_service_settings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/test-optimization/settings/service",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::DELETE, local_uri_str.as_str());
@@ -332,13 +332,13 @@ impl TestOptimizationAPI {
         datadog::Error<GetFlakyTestsManagementPoliciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_flaky_tests_management_policies";
+        let local_operation_id = "v2.get_flaky_tests_management_policies";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/test-optimization/settings/policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -491,13 +491,13 @@ impl TestOptimizationAPI {
         datadog::Error<GetTestOptimizationServiceSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_test_optimization_service_settings";
+        let local_operation_id = "v2.get_test_optimization_service_settings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/test-optimization/settings/service",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -719,7 +719,7 @@ impl TestOptimizationAPI {
         datadog::Error<SearchFlakyTestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_flaky_tests";
+        let local_operation_id = "v2.search_flaky_tests";
 
         // unbox and build optional parameters
         let body = params.body;
@@ -728,7 +728,7 @@ impl TestOptimizationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/test/flaky-test-management/tests",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -877,13 +877,13 @@ impl TestOptimizationAPI {
         datadog::Error<UpdateFlakyTestsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_flaky_tests";
+        let local_operation_id = "v2.update_flaky_tests";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/test/flaky-test-management/tests",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -1039,13 +1039,13 @@ impl TestOptimizationAPI {
         datadog::Error<UpdateFlakyTestsManagementPoliciesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_flaky_tests_management_policies";
+        let local_operation_id = "v2.update_flaky_tests_management_policies";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/test-optimization/settings/policies",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -1204,13 +1204,13 @@ impl TestOptimizationAPI {
         datadog::Error<UpdateTestOptimizationServiceSettingsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_test_optimization_service_settings";
+        let local_operation_id = "v2.update_test_optimization_service_settings";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/ci/test-optimization/settings/service",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());

--- a/src/datadogV2/api/api_usage_metering.rs
+++ b/src/datadogV2/api/api_usage_metering.rs
@@ -540,13 +540,13 @@ impl UsageMeteringAPI {
         datadog::Error<GetActiveBillingDimensionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_active_billing_dimensions";
+        let local_operation_id = "v2.get_active_billing_dimensions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/cost_by_tag/active_billing_dimensions",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -660,7 +660,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetBillingDimensionMappingError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_billing_dimension_mapping";
+        let local_operation_id = "v2.get_billing_dimension_mapping";
 
         // unbox and build optional parameters
         let filter_month = params.filter_month;
@@ -670,7 +670,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/billing_dimension_mapping",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -800,7 +800,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetCostByOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_cost_by_org";
+        let local_operation_id = "v2.get_cost_by_org";
 
         // unbox and build optional parameters
         let end_month = params.end_month;
@@ -809,7 +809,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/cost_by_org",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -933,7 +933,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetEstimatedCostByOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_estimated_cost_by_org";
+        let local_operation_id = "v2.get_estimated_cost_by_org";
 
         // unbox and build optional parameters
         let view = params.view;
@@ -948,7 +948,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/estimated_cost",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1100,7 +1100,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetHistoricalCostByOrgError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_historical_cost_by_org";
+        let local_operation_id = "v2.get_historical_cost_by_org";
 
         // unbox and build optional parameters
         let view = params.view;
@@ -1111,7 +1111,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/historical_cost",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1243,7 +1243,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetHourlyUsageError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_hourly_usage";
+        let local_operation_id = "v2.get_hourly_usage";
 
         // unbox and build optional parameters
         let filter_timestamp_end = params.filter_timestamp_end;
@@ -1258,7 +1258,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/hourly_usage",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1443,7 +1443,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetMonthlyCostAttributionError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_monthly_cost_attribution";
+        let local_operation_id = "v2.get_monthly_cost_attribution";
 
         // unbox and build optional parameters
         let end_month = params.end_month;
@@ -1457,7 +1457,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/cost_by_tag/monthly_cost_attribution",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1598,7 +1598,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetProjectedCostError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_projected_cost";
+        let local_operation_id = "v2.get_projected_cost";
 
         // unbox and build optional parameters
         let view = params.view;
@@ -1608,7 +1608,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/projected_cost",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1731,7 +1731,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageApplicationSecurityMonitoringError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_usage_application_security_monitoring";
+        let local_operation_id = "v2.get_usage_application_security_monitoring";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -1740,7 +1740,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/application_security",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1855,13 +1855,13 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageAttributionTypesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_usage_attribution_types";
+        let local_operation_id = "v2.get_usage_attribution_types";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/usage/usage-attribution-types",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1973,7 +1973,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageLambdaTracedInvocationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_usage_lambda_traced_invocations";
+        let local_operation_id = "v2.get_usage_lambda_traced_invocations";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -1982,7 +1982,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/lambda_traced_invocations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2106,7 +2106,7 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageObservabilityPipelinesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_usage_observability_pipelines";
+        let local_operation_id = "v2.get_usage_observability_pipelines";
 
         // unbox and build optional parameters
         let end_hr = params.end_hr;
@@ -2115,7 +2115,7 @@ impl UsageMeteringAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/usage/observability_pipelines",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -2306,13 +2306,13 @@ impl UsageMeteringAPI {
         datadog::Error<GetUsageSummaryAvailableFieldsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_usage_summary_available_fields";
+        let local_operation_id = "v2.get_usage_summary_available_fields";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/usage/summary/available_fields",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_user_authorized_clients.rs
+++ b/src/datadogV2/api/api_user_authorized_clients.rs
@@ -181,13 +181,13 @@ impl UserAuthorizedClientsAPI {
         user_authorized_client_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteUserAuthorizedClientError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_user_authorized_client";
+        let local_operation_id = "v2.delete_user_authorized_client";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/user_authorized_clients/{user_authorized_client_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_authorized_client_id = datadog::urlencode(user_authorized_client_id)
         );
         let mut local_req_builder =
@@ -275,13 +275,13 @@ impl UserAuthorizedClientsAPI {
         datadog::Error<DeleteUserAuthorizedClientsByClientError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_user_authorized_clients_by_client";
+        let local_operation_id = "v2.delete_user_authorized_clients_by_client";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/user_authorized_clients/client/{client_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             client_id = datadog::urlencode(client_id)
         );
         let mut local_req_builder =
@@ -380,13 +380,13 @@ impl UserAuthorizedClientsAPI {
         datadog::Error<GetUserAuthorizedClientError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_user_authorized_client";
+        let local_operation_id = "v2.get_user_authorized_client";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/user_authorized_clients/{user_authorized_client_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_authorized_client_id = datadog::urlencode(user_authorized_client_id)
         );
         let mut local_req_builder =
@@ -527,7 +527,7 @@ impl UserAuthorizedClientsAPI {
         datadog::Error<ListUserAuthorizedClientsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_user_authorized_clients";
+        let local_operation_id = "v2.list_user_authorized_clients";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -540,7 +540,7 @@ impl UserAuthorizedClientsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/user_authorized_clients",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());

--- a/src/datadogV2/api/api_users.rs
+++ b/src/datadogV2/api/api_users.rs
@@ -299,9 +299,9 @@ impl UsersAPI {
         datadog::Error<AnonymizeUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.anonymize_users";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.anonymize_users";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.anonymize_users' is not enabled".to_string(),
@@ -313,7 +313,7 @@ impl UsersAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/anonymize_users",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PUT, local_uri_str.as_str());
@@ -459,13 +459,13 @@ impl UsersAPI {
         datadog::Error<CreateUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_user";
+        let local_operation_id = "v2.create_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -599,13 +599,13 @@ impl UsersAPI {
         user_id: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteUserInvitationsError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_user_invitations";
+        let local_operation_id = "v2.delete_user_invitations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}/invitations",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id.to_string())
         );
         let mut local_req_builder =
@@ -689,13 +689,13 @@ impl UsersAPI {
         user_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DisableUserError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.disable_user";
+        let local_operation_id = "v2.disable_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -793,13 +793,13 @@ impl UsersAPI {
         datadog::Error<GetCurrentUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_current_user";
+        let local_operation_id = "v2.get_current_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/current_user",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -900,13 +900,13 @@ impl UsersAPI {
         datadog::Error<GetInvitationError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_invitation";
+        let local_operation_id = "v2.get_invitation";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/user_invitations/{user_invitation_uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_invitation_uuid = datadog::urlencode(user_invitation_uuid)
         );
         let mut local_req_builder =
@@ -1006,13 +1006,13 @@ impl UsersAPI {
         datadog::Error<GetUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_user";
+        let local_operation_id = "v2.get_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -1117,13 +1117,13 @@ impl UsersAPI {
         datadog::Error<GetUserIdentityProvidersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_user_identity_providers";
+        let local_operation_id = "v2.get_user_identity_providers";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}/identity_providers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -1227,13 +1227,13 @@ impl UsersAPI {
         datadog::Error<ListUserOrganizationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_user_organizations";
+        let local_operation_id = "v2.list_user_organizations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}/orgs",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -1336,13 +1336,13 @@ impl UsersAPI {
         datadog::Error<ListUserPermissionsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_user_permissions";
+        let local_operation_id = "v2.list_user_permissions";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}/permissions",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -1476,7 +1476,7 @@ impl UsersAPI {
         datadog::Error<ListUsersError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_users";
+        let local_operation_id = "v2.list_users";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1490,7 +1490,7 @@ impl UsersAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/users",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1614,13 +1614,13 @@ impl UsersAPI {
         datadog::Error<SendInvitationsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.send_invitations";
+        let local_operation_id = "v2.send_invitations";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/user_invitations",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -1774,13 +1774,13 @@ impl UsersAPI {
         datadog::Error<UpdateCurrentUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_current_user";
+        let local_operation_id = "v2.update_current_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/current_user",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::PATCH, local_uri_str.as_str());
@@ -1928,13 +1928,13 @@ impl UsersAPI {
         datadog::Error<UpdateUserError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_user";
+        let local_operation_id = "v2.update_user";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =
@@ -2077,13 +2077,13 @@ impl UsersAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<UpdateUserIdentityProvidersError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_user_identity_providers";
+        let local_operation_id = "v2.update_user_identity_providers";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/users/{user_id}/relationships/identity_providers",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             user_id = datadog::urlencode(user_id)
         );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_web_integrations.rs
+++ b/src/datadogV2/api/api_web_integrations.rs
@@ -164,9 +164,9 @@ impl WebIntegrationsAPI {
         datadog::Error<CreateWebIntegrationAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_web_integration_account";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.create_web_integration_account";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.create_web_integration_account' is not enabled".to_string(),
@@ -178,7 +178,7 @@ impl WebIntegrationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/web-integrations/{integration_name}/accounts",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_name = datadog::urlencode(integration_name)
         );
         let mut local_req_builder =
@@ -320,9 +320,9 @@ impl WebIntegrationsAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteWebIntegrationAccountError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_web_integration_account";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.delete_web_integration_account";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.delete_web_integration_account' is not enabled".to_string(),
@@ -334,7 +334,7 @@ impl WebIntegrationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/web-integrations/{integration_name}/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_name = datadog::urlencode(integration_name),
             account_id = datadog::urlencode(account_id)
         );
@@ -436,9 +436,9 @@ impl WebIntegrationsAPI {
         datadog::Error<GetWebIntegrationAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_web_integration_account";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.get_web_integration_account";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.get_web_integration_account' is not enabled".to_string(),
@@ -450,7 +450,7 @@ impl WebIntegrationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/web-integrations/{integration_name}/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_name = datadog::urlencode(integration_name),
             account_id = datadog::urlencode(account_id)
         );
@@ -557,9 +557,9 @@ impl WebIntegrationsAPI {
         datadog::Error<ListWebIntegrationAccountsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_web_integration_accounts";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.list_web_integration_accounts";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.list_web_integration_accounts' is not enabled".to_string(),
@@ -571,7 +571,7 @@ impl WebIntegrationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/web-integrations/{integration_name}/accounts",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_name = datadog::urlencode(integration_name)
         );
         let mut local_req_builder =
@@ -681,9 +681,9 @@ impl WebIntegrationsAPI {
         datadog::Error<UpdateWebIntegrationAccountError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_web_integration_account";
-        if local_configuration.is_unstable_operation_enabled(operation_id) {
-            warn!("Using unstable operation {operation_id}");
+        let local_operation_id = "v2.update_web_integration_account";
+        if local_configuration.is_unstable_operation_enabled(local_operation_id) {
+            warn!("Using unstable operation {local_operation_id}");
         } else {
             let local_error = datadog::UnstableOperationDisabledError {
                 msg: "Operation 'v2.update_web_integration_account' is not enabled".to_string(),
@@ -695,7 +695,7 @@ impl WebIntegrationsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/web-integrations/{integration_name}/accounts/{account_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             integration_name = datadog::urlencode(integration_name),
             account_id = datadog::urlencode(account_id)
         );

--- a/src/datadogV2/api/api_webhooks_integration.rs
+++ b/src/datadogV2/api/api_webhooks_integration.rs
@@ -177,13 +177,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<CreateOAuth2ClientCredentialsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_o_auth2_client_credentials";
+        let local_operation_id = "v2.create_o_auth2_client_credentials";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/webhooks/configuration/auth-method/oauth2-client-credentials",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -323,13 +323,13 @@ impl WebhooksIntegrationAPI {
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteOAuth2ClientCredentialsError>>
     {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_o_auth2_client_credentials";
+        let local_operation_id = "v2.delete_o_auth2_client_credentials";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/webhooks/configuration/auth-method/oauth2-client-credentials/{auth_method_id}",
-            local_configuration.get_operation_host(operation_id), auth_method_id=
+            local_configuration.get_operation_host(local_operation_id), auth_method_id=
             datadog::urlencode(auth_method_id)
             );
         let mut local_req_builder =
@@ -427,7 +427,7 @@ impl WebhooksIntegrationAPI {
         datadog::Error<GetAllAuthMethodsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_all_auth_methods";
+        let local_operation_id = "v2.get_all_auth_methods";
 
         // unbox and build optional parameters
         let include = params.include;
@@ -436,7 +436,7 @@ impl WebhooksIntegrationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/integration/webhooks/configuration/auth-method",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -546,13 +546,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<GetOAuth2ClientCredentialsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_o_auth2_client_credentials";
+        let local_operation_id = "v2.get_o_auth2_client_credentials";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/webhooks/configuration/auth-method/oauth2-client-credentials/{auth_method_id}",
-            local_configuration.get_operation_host(operation_id), auth_method_id=
+            local_configuration.get_operation_host(local_operation_id), auth_method_id=
             datadog::urlencode(auth_method_id)
             );
         let mut local_req_builder =
@@ -661,13 +661,13 @@ impl WebhooksIntegrationAPI {
         datadog::Error<UpdateOAuth2ClientCredentialsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_o_auth2_client_credentials";
+        let local_operation_id = "v2.update_o_auth2_client_credentials";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/integration/webhooks/configuration/auth-method/oauth2-client-credentials/{auth_method_id}",
-            local_configuration.get_operation_host(operation_id), auth_method_id=
+            local_configuration.get_operation_host(local_operation_id), auth_method_id=
             datadog::urlencode(auth_method_id)
             );
         let mut local_req_builder =

--- a/src/datadogV2/api/api_widgets.rs
+++ b/src/datadogV2/api/api_widgets.rs
@@ -238,13 +238,13 @@ impl WidgetsAPI {
         datadog::Error<CreateWidgetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_widget";
+        let local_operation_id = "v2.create_widget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/widgets/{experience_type}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experience_type = datadog::urlencode(experience_type.to_string())
         );
         let mut local_req_builder =
@@ -382,13 +382,13 @@ impl WidgetsAPI {
         uuid: uuid::Uuid,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteWidgetError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_widget";
+        let local_operation_id = "v2.delete_widget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/widgets/{experience_type}/{uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experience_type = datadog::urlencode(experience_type.to_string()),
             uuid = datadog::urlencode(uuid.to_string())
         );
@@ -483,13 +483,13 @@ impl WidgetsAPI {
         datadog::Error<GetWidgetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_widget";
+        let local_operation_id = "v2.get_widget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/widgets/{experience_type}/{uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experience_type = datadog::urlencode(experience_type.to_string()),
             uuid = datadog::urlencode(uuid.to_string())
         );
@@ -611,7 +611,7 @@ impl WidgetsAPI {
         datadog::Error<SearchWidgetsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.search_widgets";
+        let local_operation_id = "v2.search_widgets";
 
         // unbox and build optional parameters
         let filter_widget_type = params.filter_widget_type;
@@ -627,7 +627,7 @@ impl WidgetsAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/widgets/{experience_type}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experience_type = datadog::urlencode(experience_type.to_string())
         );
         let mut local_req_builder =
@@ -767,13 +767,13 @@ impl WidgetsAPI {
         datadog::Error<UpdateWidgetError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_widget";
+        let local_operation_id = "v2.update_widget";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/widgets/{experience_type}/{uuid}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             experience_type = datadog::urlencode(experience_type.to_string()),
             uuid = datadog::urlencode(uuid.to_string())
         );

--- a/src/datadogV2/api/api_workflow_automation.rs
+++ b/src/datadogV2/api/api_workflow_automation.rs
@@ -275,13 +275,13 @@ impl WorkflowAutomationAPI {
         datadog::Error<CancelWorkflowInstanceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.cancel_workflow_instance";
+        let local_operation_id = "v2.cancel_workflow_instance";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/workflows/{workflow_id}/instances/{instance_id}/cancel",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             workflow_id = datadog::urlencode(workflow_id),
             instance_id = datadog::urlencode(instance_id)
         );
@@ -383,13 +383,13 @@ impl WorkflowAutomationAPI {
         datadog::Error<CreateWorkflowError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_workflow";
+        let local_operation_id = "v2.create_workflow";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/workflows",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::POST, local_uri_str.as_str());
@@ -543,13 +543,13 @@ impl WorkflowAutomationAPI {
         datadog::Error<CreateWorkflowInstanceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.create_workflow_instance";
+        let local_operation_id = "v2.create_workflow_instance";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/workflows/{workflow_id}/instances",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             workflow_id = datadog::urlencode(workflow_id)
         );
         let mut local_req_builder =
@@ -685,13 +685,13 @@ impl WorkflowAutomationAPI {
         workflow_id: String,
     ) -> Result<datadog::ResponseContent<()>, datadog::Error<DeleteWorkflowError>> {
         let local_configuration = &self.config;
-        let operation_id = "v2.delete_workflow";
+        let local_operation_id = "v2.delete_workflow";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/workflows/{workflow_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             workflow_id = datadog::urlencode(workflow_id)
         );
         let mut local_req_builder =
@@ -785,13 +785,13 @@ impl WorkflowAutomationAPI {
         datadog::Error<GetWorkflowError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_workflow";
+        let local_operation_id = "v2.get_workflow";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/workflows/{workflow_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             workflow_id = datadog::urlencode(workflow_id)
         );
         let mut local_req_builder =
@@ -898,13 +898,13 @@ impl WorkflowAutomationAPI {
         datadog::Error<GetWorkflowInstanceError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.get_workflow_instance";
+        let local_operation_id = "v2.get_workflow_instance";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/workflows/{workflow_id}/instances/{instance_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             workflow_id = datadog::urlencode(workflow_id),
             instance_id = datadog::urlencode(instance_id)
         );
@@ -1013,7 +1013,7 @@ impl WorkflowAutomationAPI {
         datadog::Error<ListWorkflowInstancesError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_workflow_instances";
+        let local_operation_id = "v2.list_workflow_instances";
 
         // unbox and build optional parameters
         let page_size = params.page_size;
@@ -1023,7 +1023,7 @@ impl WorkflowAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/workflows/{workflow_id}/instances",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             workflow_id = datadog::urlencode(workflow_id)
         );
         let mut local_req_builder =
@@ -1169,7 +1169,7 @@ impl WorkflowAutomationAPI {
         datadog::Error<ListWorkflowsError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.list_workflows";
+        let local_operation_id = "v2.list_workflows";
 
         // unbox and build optional parameters
         let limit = params.limit;
@@ -1184,7 +1184,7 @@ impl WorkflowAutomationAPI {
 
         let local_uri_str = format!(
             "{}/api/v2/workflows",
-            local_configuration.get_operation_host(operation_id)
+            local_configuration.get_operation_host(local_operation_id)
         );
         let mut local_req_builder =
             local_client.request(reqwest::Method::GET, local_uri_str.as_str());
@@ -1317,13 +1317,13 @@ impl WorkflowAutomationAPI {
         datadog::Error<UpdateWorkflowError>,
     > {
         let local_configuration = &self.config;
-        let operation_id = "v2.update_workflow";
+        let local_operation_id = "v2.update_workflow";
 
         let local_client = &self.client;
 
         let local_uri_str = format!(
             "{}/api/v2/workflows/{workflow_id}",
-            local_configuration.get_operation_host(operation_id),
+            local_configuration.get_operation_host(local_operation_id),
             workflow_id = datadog::urlencode(workflow_id)
         );
         let mut local_req_builder =


### PR DESCRIPTION
## Summary

`ListRUMOperationStrongLinks` (moving to GA as part of DataDog/datadog-api-spec#6240) is the first operation in the entire spec to have a parameter literally named `operation_id`. That collides with an internal variable of the same name that `.generator/src/generator/templates/api.j2` declares for every operation to resolve the per-operation server host:

```
let operation_id = "v2.list_rum_operation_strong_links";
...
let operation_id = params.operation_id;   // unboxes the real query param, Option<String>
...
local_configuration.get_operation_host(operation_id)  // now gets Option<String>, not &str
```

Rust shadowing means the second `let` silently wins, so `get_operation_host` receives an `Option<String>` where it expects `&str`:

```
error[E0308]: mismatched types
   --> src/datadogV2/api/api_rum_operations.rs:973:52
    |
973 |             local_configuration.get_operation_host(operation_id));
    |                                 ------------------ ^^^^^^^^^^^^ expected `&str`, found `Option<String>`
```

This has been a latent hazard since `operation_id`-based host resolution was introduced in #15 (Feb 2024) — it just never had a colliding parameter name to trigger it until now.

## Fix

Rename the internal literal to `local_operation_id`, matching the `local_` prefix convention every other generator-internal variable in this function already follows (`local_configuration`, `local_client`, `local_uri_str`, `local_req_builder`, `local_query_param`, `local_error`). This is the one internal variable that didn't follow that convention.

The wire contract is unaffected — the query parameter is still sent as `operation_id` (the key comes from a separate literal in the template, not from the Rust variable name).

## Verification

- Reproduced the failure by regenerating the client from the actual bundled spec in DataDog/datadog-api-spec#6240.
- Applied the fix and regenerated the full client (v1 + v2, ~180 API files).
- Diffed every changed file byte-for-byte against the pre-fix output after normalizing `local_operation_id` back to `operation_id`: the only difference anywhere in the generated codebase is that token rename — nothing else changed.
- Confirmed no parameter anywhere in the spec is named `local_operation_id`, `local_configuration`, `local_client`, etc., so this can't reintroduce the same collision.

## Test plan

- [ ] CI regenerates and compiles `api_rum_operations.rs` (and all other operations) successfully once DataDog/datadog-api-spec#6240 merges