### PR TITLE
Use dd-sts for Datadog credentials instead of long-lived secrets

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -23,14 +23,6 @@ on:
         required: false
         type: string
         default: 'cargo check --examples'
-    secrets:
-      # Integration test secrets
-      DD_API_KEY:
-        required: false
-      DD_CLIENT_API_KEY:
-        required: false
-      DD_CLIENT_APP_KEY:
-        required: false
 
 jobs:
   pre-commit:
@@ -60,7 +52,3 @@ jobs:
     with:
       target-branch: ${{ inputs.target-branch }}
       has-integration-label: ${{ contains(github.event.pull_request.labels.*.name, 'ci/integrations') }}
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      DD_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
-      DD_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -43,13 +43,6 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      DD_API_KEY:
-        required: true
-      DD_CLIENT_API_KEY:
-        required: true
-      DD_CLIENT_APP_KEY:
-        required: true
 
 concurrency:
   group: integration-rust-${{ inputs.target-branch || github.head_ref }}
@@ -69,16 +62,31 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    services:
-      datadog-agent:
-        image: gcr.io/datadoghq/agent:latest
-        ports:
-          - 8126:8126
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_HOSTNAME: "none"
-          DD_INSIDE_CI: "true"
     steps:
+      - name: Get Datadog credentials
+        id: dd-sts
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: datadog-api-client-rust
+      - name: Start Datadog Agent
+        run: |
+          docker run -d --name datadog-agent \
+            -p 8126:8126 \
+            -e DD_API_KEY=${{ steps.dd-sts.outputs.api_key }} \
+            -e DD_HOSTNAME=none \
+            -e DD_INSIDE_CI=true \
+            gcr.io/datadoghq/agent:latest
+          # Wait for agent to be ready
+          for i in $(seq 1 30); do
+            if docker inspect --format='{{.State.Health.Status}}' datadog-agent 2>/dev/null | grep -q healthy; then
+              echo "Datadog Agent is healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Datadog Agent failed to become healthy"
+          docker logs datadog-agent
+          exit 1
       - name: Get GitHub App token
         if: github.event_name == 'pull_request'
         id: get_token
@@ -119,8 +127,8 @@ jobs:
           DD_ENV: prod
           DD_SERVICE: datadog-api-client-rust
           DD_TAGS: "team:integrations-tools-and-libraries"
-          DD_TEST_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
-          DD_TEST_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}
+          DD_TEST_CLIENT_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DD_TEST_CLIENT_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
           RECORD: "none"
       - name: Post failure status check
         if: failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')


### PR DESCRIPTION
## Summary

Replace long-lived GitHub Actions secrets (DD_API_KEY, DD_CLIENT_API_KEY, DD_CLIENT_APP_KEY) with short-lived credentials obtained via dd-sts OIDC token exchange.

## Changes

### reusable-integration-test.yml
- Split into two jobs: get-credentials (runs dd-sts-action) -> integration_tests (uses the credentials)
- DD_API_KEY in the Datadog Agent service container now comes from needs.get-credentials.outputs.api_key
- DD_TEST_CLIENT_API_KEY and DD_TEST_CLIENT_APP_KEY now come from dd-sts outputs
- Removed DD_API_KEY, DD_CLIENT_API_KEY, DD_CLIENT_APP_KEY from the secrets declaration

The two-job split is needed because GitHub Actions service containers start before any step runs, so they cannot reference step outputs directly. Job outputs (via needs) are resolved before the job starts, so they work in service container env vars.

### reusable-ci.yml
- Removed DD_API_KEY, DD_CLIENT_API_KEY, DD_CLIENT_APP_KEY from secrets declaration and the integration job pass-through

## Dependencies

- dd-source PR #60511 (merged) - adds the datadog-api-client-rust dd-sts policy

## After merge

The three secrets (DD_API_KEY, DD_CLIENT_API_KEY, DD_CLIENT_APP_KEY) can be removed from this repo GitHub Actions secrets settings.

## Related

Part of a broader effort (led by CI/CD Security / Nicole Maldonado) to remove long-lived credentials from GitHub Actions across all datadog-api-client-* repos. See the dd-sts user guide: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5769659435/User+guide+dd-sts