### PR TITLE
ci: free runner disk space on rust test and examples jobs

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -21,11 +21,30 @@ on:
 jobs:
   examples:
     runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-rust
           ref: ${{ inputs.target-branch || github.ref }}
+      - name: Free disk space
+        shell: bash
+        run: |
+          echo "Disk before cleanup:"
+          df -h /
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift \
+            /usr/local/share/powershell || true
+          sudo docker image prune --all --force || true
+          echo "Disk after cleanup:"
+          df -h /
       - name: Install Rust
         run: rustup toolchain install ${{ inputs.rust-version }} --profile minimal --no-self-update && rustup default ${{ inputs.rust-version }}
         shell: bash

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -26,12 +26,34 @@ jobs:
         rust-version: ${{ fromJSON(inputs.rust-versions) }}
         platform: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ matrix.platform }}
+    env:
+      # Keep file:line in panics while cutting multi-GB debuginfo on this generated crate.
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-rust
           ref: ${{ inputs.target-branch || github.ref }}
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "Disk before cleanup:"
+          df -h /
+          # ubuntu-latest only guarantees ~14GB free; this crate's debug target can exceed that.
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift \
+            /usr/local/share/powershell || true
+          sudo docker image prune --all --force || true
+          echo "Disk after cleanup:"
+          df -h /
       - name: Install Rust
         id: rust
         run: |
@@ -51,7 +73,6 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-
       - name: Compile test binary
         run: cargo test --test main --no-run
         shell: bash
@@ -59,7 +80,13 @@ jobs:
         shell: bash
         run: |
           BINARY=$(find target/debug/deps -name 'main-*' -executable -type f | head -1)
-          cp "$BINARY" test-binary
+          if [ -z "$BINARY" ]; then
+            echo "No compiled test binary found in target/debug/deps"
+            ls -la target/debug/deps || true
+            exit 1
+          fi
+          echo "Staging $BINARY ($(du -h "$BINARY" | cut -f1))"
+          mv "$BINARY" test-binary
       - name: Upload test binary
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### What does this PR do?

Reusable `test` / `examples` jobs have been dying on `ubuntu-latest` with `No space left on device` (the Actions worker cannot even write its diagnostic log). The generated client is ~11k Rust files; a debug `target/` plus a copied test binary exceeds the ~14GB the runner guarantees.

This:

- Reclaims unused preinstalled SDKs (.NET, Android, GHC, CodeQL, Swift, PowerShell) and prunes Docker images before compile
- Sets `CARGO_PROFILE_TEST_DEBUG` / `CARGO_PROFILE_DEV_DEBUG` to `line-tables-only` so we keep file:line in panics without multi-GB debuginfo
- Disables incremental compilation in CI
- Stops restoring stale `target/` caches via `restore-keys` on the test build job
- `mv`s the test binary instead of `cp`ing it

Example failure: https://github.com/DataDog/datadog-api-spec/actions/runs/32410506327/job/96657126869

### Additional Notes

`datadog-api-spec` pins `reusable-ci.yml` by SHA, so a follow-up pin bump is needed there for generated-client CI to pick this up.

### Review checklist

- [x] This PR includes all [newly recorded cassettes](/DEVELOPMENT.md) for any modified tests.
- [x] This PR does not rely on API client schema changes.
  - [ ] The CI should be fully passing.
- [ ] Or, this PR relies on API schema changes and this is a Draft PR to include tests for that new functionality.


Made with [Cursor](https://cursor.com)