### PR TITLE
Speed up Cargo CI caching

### DIFF
--- a/.github/workflows/reusable-examples.yml
+++ b/.github/workflows/reusable-examples.yml
@@ -21,23 +21,41 @@ on:
 jobs:
   examples:
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: DataDog/datadog-api-client-rust
           ref: ${{ inputs.target-branch || github.ref }}
       - name: Install Rust
-        run: rustup toolchain install ${{ inputs.rust-version }} --profile minimal --no-self-update && rustup default ${{ inputs.rust-version }}
+        id: rust
+        run: |
+          rustup toolchain install ${{ inputs.rust-version }} --profile minimal --no-self-update && rustup default ${{ inputs.rust-version }}
+          echo "version=$(rustc --version | awk '{print $2}')" >> $GITHUB_OUTPUT
         shell: bash
-      - name: Cache Cargo
+      - name: Cache Cargo registry
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Resolve Cargo dependencies
+        run: cargo generate-lockfile
+        shell: bash
+      - name: Cache Cargo build
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-examples-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-examples-
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-
       - name: Check examples
         run: ${{ inputs.examples-command }}
+        shell: bash
+      - name: Remove workspace artifacts from cache
+        run: cargo clean --package datadog-api-client
         shell: bash

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -58,6 +58,8 @@ concurrency:
 jobs:
   integration_tests:
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
     if: >
       (github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
@@ -99,17 +101,30 @@ jobs:
           status: pending
           context: ${{ inputs.status-context || 'integration' }}
       - name: Install Rust
-        run: rustup toolchain install stable --profile minimal --no-self-update && rustup default stable
+        id: rust
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update && rustup default stable
+          echo "version=$(rustc --version | awk '{print $2}')" >> $GITHUB_OUTPUT
         shell: bash
-      - name: Cache Cargo
+      - name: Cache Cargo registry
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Resolve Cargo dependencies
+        run: cargo generate-lockfile
+        shell: bash
+      - name: Cache Cargo build
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-integration-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-integration-
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-
       - name: Run integration tests
         shell: bash
         run: ./run-tests.sh
@@ -123,6 +138,9 @@ jobs:
           DD_TEST_CLIENT_API_KEY: ${{ secrets.DD_CLIENT_API_KEY }}
           DD_TEST_CLIENT_APP_KEY: ${{ secrets.DD_CLIENT_APP_KEY }}
           RECORD: "none"
+      - name: Remove workspace artifacts from cache
+        run: cargo clean --package datadog-api-client
+        shell: bash
       - name: Post failure status check
         if: failure() && github.event_name == 'pull_request' && contains(github.event.pull_request.head.ref, 'datadog-api-spec/generated/') && (inputs.enable-status-reporting || github.event_name != 'workflow_call')
         uses: DataDog/github-actions/post-status-check@65b4875f33ad773d7ba4b005a2cb5f35020295f3 # v2.3.0

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -26,6 +26,8 @@ jobs:
         rust-version: ${{ fromJSON(inputs.rust-versions) }}
         platform: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ matrix.platform }}
+    env:
+      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,12 +48,17 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Resolve Cargo dependencies
+        run: cargo generate-lockfile
+        shell: bash
       - name: Cache Cargo build
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: target
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-
+          key: ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-test-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-test-
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-
       - name: Compile test binary
         id: compile
         run: |
@@ -69,6 +76,9 @@ jobs:
           name: test-binary-${{ matrix.rust-version }}-${{ matrix.platform }}
           path: test-binary
           retention-days: 1
+      - name: Remove workspace artifacts from cache
+        run: cargo clean --package datadog-api-client
+        shell: bash
 
   test:
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,9 @@ jobs:
        !contains(github.event.pull_request.labels.*.name, 'ci/skip') &&
        !contains(github.event.pull_request.head.ref, 'datadog-api-spec/test/')) ||
       github.event_name == 'schedule'
-    needs: test
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -105,14 +106,22 @@ jobs:
             ~/.cargo/git
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-registry-
+      - name: Resolve Cargo dependencies
+        run: cargo generate-lockfile
+        shell: bash
       - name: Cache Cargo build
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: target
-          key: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-cargo-target-${{ steps.rust.outputs.version }}-
+          key: ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-examples-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-examples-
+            ${{ runner.os }}-cargo-target-v2-${{ steps.rust.outputs.version }}-
       - name: Check examples
         run: cargo check --examples
+        shell: bash
+      - name: Remove workspace artifacts from cache
+        run: cargo clean --package datadog-api-client
         shell: bash
 
   report:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(non_snake_case)]
 #![doc = include_str!("../README.md")]
 
+/// Shared client configuration and authentication types.
 pub mod datadog;
 pub mod datadogV1;
 pub mod datadogV2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@
 
 /// Shared client configuration and authentication types.
 pub mod datadog;
+/// Types and API clients for Datadog API v1.
 pub mod datadogV1;
 pub mod datadogV2;


### PR DESCRIPTION
## Summary

- run examples concurrently with the test workflow
- cache Cargo dependency artifacts without incremental or workspace outputs
- key build caches by Rust version, workload, and the resolved dependency lockfile
- keep using the company-approved pinned actions/cache action

## Local measurements

- empty target, non-incremental compile: 3m 06s
- target size before workspace cleanup: 3.1 GB
- dependency-only target size: 1.1 GB
- rebuild from dependency-only target: 1m 52s

## GitHub Actions measurements

| Revision | Library change | Build cache | Cache restore | Compile | Build job |
| --- | --- | --- | ---: | ---: | ---: |
| Reference PR #2058 | generated operation | old 1.8 GB target cache | 28s | 6m 04s | 7m 21s |
| f567990f5 | cache implementation baseline | cold; saved 324 MB | 0s | 4m 01s | 4m 39s |
| 66a2892b7 | document shared client module | warm 324 MB dependency cache | 5s | 3m 34s | 4m 15s |
| 84a048bba | document API v1 module | warm 324 MB dependency cache | 6s | 3m 49s | 4m 35s |

The two warm library-change samples average 3m 42s compilation and 4m 25s for the complete build job.