### PR TITLE
Shard generated tests across GitHub runners

### DIFF
--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -83,9 +83,11 @@ jobs:
   test:
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         rust-version: ${{ fromJSON(inputs.rust-versions) }}
         platform: ${{ fromJSON(inputs.platforms) }}
+        shard: [1, 2, 3, 4]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -101,6 +103,8 @@ jobs:
         shell: bash
         env:
           DD_USE_GENERATED_TESTS: "true"
+          DD_TEST_SHARD: ${{ matrix.shard }}
+          DD_TEST_SHARD_TOTAL: 4
         run: |
           chmod +x test-binary
           ./test-binary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 #![allow(non_snake_case)]
 #![doc = include_str!("../README.md")]
 
-/// Shared client configuration and authentication types.
 pub mod datadog;
-/// Types and API clients for Datadog API v1.
 pub mod datadogV1;
 pub mod datadogV2;

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,4 +1,5 @@
 mod scenarios;
+mod sharding;
 
 use cucumber::{cli, parser, runner, writer, StatsWriter, World};
 use lazy_static::lazy_static;
@@ -7,6 +8,7 @@ use scenarios::fixtures::{
     after_scenario, before_scenario, given_resource_in_system, DatadogWorld,
 };
 use serde_json::Value;
+use sharding::TestShard;
 use std::{
     collections::HashMap,
     env,
@@ -156,6 +158,14 @@ async fn main() {
     };
     let parsed_cli: cli::Opts<parser::basic::Cli, runner::basic::Cli, writer::basic::Cli> =
         cli::Opts::parsed();
+    let test_shard = TestShard::from_env();
+    if let Some(shard) = test_shard {
+        println!(
+            "=== Running test shard {}/{} ===",
+            shard.number(),
+            shard.total()
+        );
+    }
     let mut cucumber = DatadogWorld::cucumber()
         .with_default_cli()
         .max_concurrent_scenarios(Some(concurrent_scenarios))
@@ -186,7 +196,7 @@ async fn main() {
     }
 
     let failed = cucumber
-        .filter_run("tests/scenarios/features/", move |_, _, sc| {
+        .filter_run("tests/scenarios/features/", move |feature, rule, sc| {
             let name_re = parsed_cli.re_filter.clone();
             let name_match = name_re
                 .and_then(|filter| Some(filter.is_match(sc.name.as_str())))
@@ -200,7 +210,14 @@ async fn main() {
             } else if is_replay && sc.tags.contains(&"integration-only".into()) {
                 false
             } else {
-                true
+                test_shard.is_none_or(|shard| {
+                    shard.includes(
+                        feature.path.as_ref().unwrap().to_string_lossy().as_ref(),
+                        rule.map(|rule| rule.name.as_str()),
+                        sc.name.as_str(),
+                        sc.position.line,
+                    )
+                })
             }
         })
         .await

--- a/tests/sharding.rs
+++ b/tests/sharding.rs
@@ -1,0 +1,107 @@
+use std::env;
+
+const SHARD_ENV: &str = "DD_TEST_SHARD";
+const SHARD_TOTAL_ENV: &str = "DD_TEST_SHARD_TOTAL";
+const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TestShard {
+    number: u64,
+    total: u64,
+}
+
+impl TestShard {
+    pub fn from_env() -> Option<Self> {
+        match (env::var(SHARD_ENV), env::var(SHARD_TOTAL_ENV)) {
+            (Err(env::VarError::NotPresent), Err(env::VarError::NotPresent)) => None,
+            (Ok(number), Ok(total)) => Some(
+                Self::new(
+                    number
+                        .parse()
+                        .unwrap_or_else(|_| panic!("{SHARD_ENV} must be a positive integer")),
+                    total
+                        .parse()
+                        .unwrap_or_else(|_| panic!("{SHARD_TOTAL_ENV} must be a positive integer")),
+                )
+                .unwrap_or_else(|error| panic!("{error}")),
+            ),
+            _ => panic!("{SHARD_ENV} and {SHARD_TOTAL_ENV} must be set together"),
+        }
+    }
+
+    fn new(number: u64, total: u64) -> Result<Self, String> {
+        if total == 0 {
+            return Err(format!("{SHARD_TOTAL_ENV} must be greater than zero"));
+        }
+        if number == 0 || number > total {
+            return Err(format!("{SHARD_ENV} must be between 1 and {total}"));
+        }
+        Ok(Self { number, total })
+    }
+
+    pub fn number(self) -> u64 {
+        self.number
+    }
+
+    pub fn total(self) -> u64 {
+        self.total
+    }
+
+    pub fn includes(
+        self,
+        feature_path: &str,
+        rule_name: Option<&str>,
+        scenario_name: &str,
+        scenario_line: usize,
+    ) -> bool {
+        let mut hash = FNV_OFFSET_BASIS;
+        let scenario_line = scenario_line.to_string();
+        for component in [
+            feature_path,
+            rule_name.unwrap_or_default(),
+            scenario_name,
+            scenario_line.as_str(),
+        ] {
+            for byte in component.bytes().chain(std::iter::once(0)) {
+                hash ^= u64::from(byte);
+                hash = hash.wrapping_mul(FNV_PRIME);
+            }
+        }
+        hash % self.total == self.number - 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn validates_shard_bounds() {
+        assert!(super::TestShard::new(0, 4).is_err());
+        assert!(super::TestShard::new(5, 4).is_err());
+        assert!(super::TestShard::new(1, 0).is_err());
+        assert_eq!(super::TestShard::new(1, 4).unwrap().number(), 1);
+    }
+
+    #[test]
+    fn assigns_each_scenario_to_exactly_one_shard() {
+        for scenario in [
+            ("features/v1/metrics.feature", None, "list metrics", 10),
+            (
+                "features/v2/monitors.feature",
+                Some("monitor rules"),
+                "create monitor",
+                42,
+            ),
+            ("features/v2/users.feature", None, "list users", 18),
+        ] {
+            let matching = (1..=4)
+                .filter(|number| {
+                    super::TestShard::new(*number, 4)
+                        .unwrap()
+                        .includes(scenario.0, scenario.1, scenario.2, scenario.3)
+                })
+                .count();
+            assert_eq!(matching, 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- reuse the single compiled Cucumber binary across four GitHub Actions matrix jobs
- assign every scenario deterministically to exactly one shard
- preserve unsharded behavior when the shard environment variables are absent
- revert the temporary `src/lib.rs` benchmark comments

## Baseline

The latest unsharded run executed 1,682 scenarios. Its `Run tests` step took 5m55s and the complete test job took 6m12s.

## Validation

- `cargo fmt -- --check`
- `CARGO_INCREMENTAL=0 cargo check --test main`
- `CARGO_INCREMENTAL=0 cargo test --test main --no-run`
- standalone sharding unit tests (2 passed)
- workflow YAML parse and `git diff --check`